### PR TITLE
Implement persistent sessions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,9 @@ const (
 	SERVICE_TO_SERVICE_CREDENTIALS             = "Service_To_Service_Credentials"
 	PROFILE                                    = "Enable_Profile"
 	MQTT_BROKER_ADDRESS                        = "MQTT_Broker_Address"
+	MQTT_CLIENT_ID                             = "MQTT_Client_Id"
+	MQTT_CLEAN_SESSION                         = "MQTT_Clean_Session"
+	MQTT_RESUME_SUBS                           = "MQTT_Resume_Subs"
 	MQTT_BROKER_TLS_CERT_FILE                  = "MQTT_Broker_Tls_Cert_File"
 	MQTT_BROKER_TLS_KEY_FILE                   = "MQTT_Broker_Tls_Key_File"
 	MQTT_BROKER_TLS_CA_CERT_FILE               = "MQTT_Broker_Tls_CA_Cert_File"
@@ -42,6 +45,9 @@ type Config struct {
 	ServiceToServiceCredentials         map[string]interface{}
 	Profile                             bool
 	MqttBrokerAddress                   string
+	MqttClientId                        string
+	MqttCleanSession                    bool
+	MqttResumeSubs                      bool
 	MqttBrokerTlsCertFile               string
 	MqttBrokerTlsKeyFile                string
 	MqttBrokerTlsCACertFile             string
@@ -63,6 +69,9 @@ func (c Config) String() string {
 	fmt.Fprintf(&b, "%s: %s\n", HTTP_SHUTDOWN_TIMEOUT, c.HttpShutdownTimeout)
 	fmt.Fprintf(&b, "%s: %t\n", PROFILE, c.Profile)
 	fmt.Fprintf(&b, "%s: %s\n", MQTT_BROKER_ADDRESS, c.MqttBrokerAddress)
+	fmt.Fprintf(&b, "%s: %s\n", MQTT_CLIENT_ID, c.MqttClientId)
+	fmt.Fprintf(&b, "%s: %v\n", MQTT_CLEAN_SESSION, c.MqttCleanSession)
+	fmt.Fprintf(&b, "%s: %v\n", MQTT_RESUME_SUBS, c.MqttResumeSubs)
 	fmt.Fprintf(&b, "%s: %s\n", MQTT_BROKER_TLS_CERT_FILE, c.MqttBrokerTlsCertFile)
 	fmt.Fprintf(&b, "%s: %s\n", MQTT_BROKER_TLS_KEY_FILE, c.MqttBrokerTlsKeyFile)
 	fmt.Fprintf(&b, "%s: %s\n", MQTT_BROKER_TLS_CA_CERT_FILE, c.MqttBrokerTlsCACertFile)
@@ -88,6 +97,9 @@ func GetConfig() *Config {
 	options.SetDefault(PROFILE, false)
 	options.SetDefault(KAFKA_BROKERS, []string{DEFAULT_KAFKA_BROKER_ADDRESS})
 	options.SetDefault(MQTT_BROKER_ADDRESS, DEFAULT_MQTT_BROKER_ADDRESS)
+	options.SetDefault(MQTT_CLIENT_ID, "connector-service")
+	options.SetDefault(MQTT_CLEAN_SESSION, false)
+	options.SetDefault(MQTT_RESUME_SUBS, true)
 	options.SetDefault(MQTT_BROKER_TLS_SKIP_VERIFY, false)
 	options.SetDefault(MQTT_BROKER_JWT_GENERATOR_IMPL, "jwt_file_reader")
 	options.SetDefault(MQTT_BROKER_JWT_FILE, "cloud-connector-mqtt-jwt.txt")
@@ -108,6 +120,9 @@ func GetConfig() *Config {
 		Profile:                             options.GetBool(PROFILE),
 		KafkaBrokers:                        options.GetStringSlice(KAFKA_BROKERS),
 		MqttBrokerAddress:                   options.GetString(MQTT_BROKER_ADDRESS),
+		MqttClientId:                        options.GetString(MQTT_CLIENT_ID),
+		MqttCleanSession:                    options.GetBool(MQTT_CLEAN_SESSION),
+		MqttResumeSubs:                      options.GetBool(MQTT_RESUME_SUBS),
 		MqttBrokerTlsCertFile:               options.GetString(MQTT_BROKER_TLS_CERT_FILE),
 		MqttBrokerTlsKeyFile:                options.GetString(MQTT_BROKER_TLS_KEY_FILE),
 		MqttBrokerTlsCACertFile:             options.GetString(MQTT_BROKER_TLS_CA_CERT_FILE),

--- a/internal/mqtt/client_options.go
+++ b/internal/mqtt/client_options.go
@@ -42,6 +42,42 @@ func WithTlsConfig(tlsConfig *tls.Config) MqttClientOptionsFunc {
 	}
 }
 
+func WithClientID(clientID string) MqttClientOptionsFunc {
+	return func(opts *MQTT.ClientOptions) error {
+		fmt.Printf("SETTING THE CLIENT ID: %s\n", clientID)
+
+		opts.SetClientID(clientID)
+		return nil
+	}
+}
+
+func WithCleanSession(cleanSession bool) MqttClientOptionsFunc {
+	return func(opts *MQTT.ClientOptions) error {
+		fmt.Printf("SETTING THE CLEAN SESSION: %v\n", cleanSession)
+
+		opts.SetCleanSession(cleanSession)
+		return nil
+	}
+}
+
+func WithResumeSubs(resumeSubs bool) MqttClientOptionsFunc {
+	return func(opts *MQTT.ClientOptions) error {
+		fmt.Printf("SETTING THE RESUME SUBS: %v\n", resumeSubs)
+
+		opts.SetResumeSubs(resumeSubs)
+		return nil
+	}
+}
+
+func WithDefaultPublishHandler(msgHdlr MQTT.MessageHandler) MqttClientOptionsFunc {
+	return func(opts *MQTT.ClientOptions) error {
+		fmt.Println("SETTING THE DEFAULT PUBLISH HANDLER")
+
+		opts.SetDefaultPublishHandler(msgHdlr)
+		return nil
+	}
+}
+
 func NewBrokerOptions(brokerUrl string, opts ...MqttClientOptionsFunc) (*MQTT.ClientOptions, error) {
 	connOpts := MQTT.NewClientOptions()
 


### PR DESCRIPTION
Persistent sessions will allow a newly started cloud-connector to
get notified of client connections and disconnections which happened
while the cloud-connector was down.

There appears to be a bit of a race condition in the paho client.
The paho client appears to receive messages from the broker
before the subscriber is completely "wired up".  Added a default
publish handler to work around that issue.

The issue and workaround are mentioned in the Common Problems section here:
https://pkg.go.dev/github.com/eclipse/paho.mqtt.golang