### PR TITLE
[api] Add disconnect endpoint to API spec

### DIFF
--- a/internal/controller/api/api.spec.json
+++ b/internal/controller/api/api.spec.json
@@ -261,6 +261,15 @@
             "PSKAuthKey": []
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectionStatusRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK"

--- a/internal/controller/api/api.spec.json
+++ b/internal/controller/api/api.spec.json
@@ -243,6 +243,30 @@
           }
         }
       }
+    },
+    "/connection/disconnect": {
+      "post": {
+        "tags": [
+          "api",
+          "connection"
+        ],
+        "summary": "Send a disconnect request to a connected client",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "PSKAuthClientID": [],
+            "PSKAuthAccount": [],
+            "PSKAuthKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
Gathered what I could from the code. Looks like we just send an OK
status and empty JSON if the disconnect is successful. I don't see items
in the spec that account for the 400s, so I didn't put that in.

Let me know if there are additional needs or if I misread anything

RHCLOUD-12532

Signed-off-by: Stephen Adams <tsadams@gmail.com>