### PR TITLE
Fall over if an error happens while attempting to publish a mqtt message

### DIFF
--- a/internal/mqtt/message_construction.go
+++ b/internal/mqtt/message_construction.go
@@ -116,6 +116,17 @@ func sendMessage(mqttClient MQTT.Client, logger *logrus.Entry, clientID domain.C
 			logger.Error("Error sending a message to MQTT broker")
 			metrics.messagePublishedFailureCounter.Inc()
 
+			// FIXME:  This will bring down the service!  This was added to work around an
+			// issue we are seeing with the production mqtt broker.  We are running into an issue in prod where
+			// cloud-connector cannot send or receive messages.  On the sending side, we are getting an
+			// timeout error.  BUT...things never recover.  So fall over and allow openshift to restart
+			// the service.  This Fatal call needs to be removed after the mqtt broker starts behaving better.
+			go func() {
+				logger.Warn("cloud-connector is about to fall over...FIXME later!!")
+				time.Sleep(1 * time.Second) // Give us some time send the log message...to give the humans a clue to figure out what happened here...
+				logger.Fatal("ran into an mqtt error...going down")
+			}()
+
 			return
 		}
 

--- a/internal/mqtt/receptor_proxy.go
+++ b/internal/mqtt/receptor_proxy.go
@@ -58,18 +58,6 @@ func (rhp *ReceptorMQTTProxy) Ping(ctx context.Context, accountNumber domain.Acc
 
 	_, err := sendControlMessage(rhp.Client, logger, topic, qos, rhp.ClientID, "command", &commandMessageContent)
 
-            // FIXME:  This will bring down the service!  This was added to work around an
-            // issue we are seeing with the production mqtt broker.  We are running into an issue in prod where
-            // cloud-connector cannot send or receive messages.  On the sending side, we are getting an
-            // timeout error.  BUT...things never recover.  So fall over and allow openshift to restart
-            // the service.  This Fatal call needs to be removed after the mqtt broker starts behaving better.
-            go func() {
-                logger.Warn("cloud-connector is about to fall over...FIXME later!!")
-                time.Sleep(1 * time.Second)  // Give us some time send the log message...to give the humans a clue to figure out what happened here...
-	            logger.Fatal("ran into an mqtt error...going down")
-            }()
-
-
 	return err
 }
 


### PR DESCRIPTION
This is going to kick over the service if it receives an error while trying to publish an mqtt message.  I'm spawning a new go routine and sleeping for 1 second before taking the poison pill.  Hopefully the 1 second sleep time gives the logs enough time to get sent to cloudwatch.

OpenShift will recognize that the service fell over and restart it automatically.

This is a temporary bandaid.

https://issues.redhat.com/browse/RHCLOUD-14297

