### PR TITLE
Don't allow empty strings for directive field (RHCLOUD-1231)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/golang-migrate/migrate/v4 v4.14.1
-	github.com/google/go-cmp v0.5.1 // indirect
+	github.com/google/go-cmp v0.5.1
 	github.com/google/uuid v1.1.4
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/gomega v1.9.0
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/prometheus/client_golang v1.9.0
-	github.com/redhatinsights/app-common-go v1.5.1 // indirect
+	github.com/redhatinsights/app-common-go v1.5.1
 	github.com/redhatinsights/platform-go-middlewares v0.8.1
 	github.com/segmentio/kafka-go v0.4.8
 	github.com/sirupsen/logrus v1.8.1

--- a/internal/controller/api/message_receiver.go
+++ b/internal/controller/api/message_receiver.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/RedHatInsights/cloud-connector/internal/config"
 	"github.com/RedHatInsights/cloud-connector/internal/connection_repository"
@@ -16,7 +17,8 @@ import (
 )
 
 const (
-	accountMismatchErrorMsg = "Account mismatch"
+	accountMismatchErrorMsg   = "Account mismatch"
+	emptyDirectictiveErrorMsg = "Directive field is empty"
 )
 
 type MessageReceiver struct {
@@ -88,6 +90,15 @@ func (jr *MessageReceiver) handleJob() http.HandlerFunc {
 			errorResponse := errorResponse{Title: accountMismatchErrorMsg,
 				Status: http.StatusForbidden,
 				Detail: accountMismatchErrorMsg}
+			writeJSONResponse(w, errorResponse.Status, errorResponse)
+			return
+		}
+
+		if len(strings.TrimSpace(msgRequest.Directive)) == 0 {
+			logger.Debug(emptyDirectictiveErrorMsg)
+			errorResponse := errorResponse{Title: emptyDirectictiveErrorMsg,
+				Status: http.StatusBadRequest,
+				Detail: emptyDirectictiveErrorMsg}
 			writeJSONResponse(w, errorResponse.Status, errorResponse)
 			return
 		}

--- a/internal/controller/api/message_receiver_test.go
+++ b/internal/controller/api/message_receiver_test.go
@@ -317,6 +317,23 @@ var _ = Describe("MessageReceiver", func() {
 				verifyErrorResponse(rr.Body, accountMismatchErrorMsg)
 			})
 
+			It("Should not allow sending a job with empty directive field", func() {
+
+				postBody := "{\"account\": \"1234\", \"recipient\": \"345\", \"payload\": [\"678\"], \"directive\": \"   \"}"
+
+				req, err := http.NewRequest("POST", MESSAGE_ENDPOINT, strings.NewReader(postBody))
+				Expect(err).NotTo(HaveOccurred())
+
+				req.Header.Add(IDENTITY_HEADER_NAME, validIdentityHeader)
+
+				rr := httptest.NewRecorder()
+
+				jr.router.ServeHTTP(rr, req)
+
+				Expect(rr.Code).To(Equal(http.StatusBadRequest))
+				verifyErrorResponse(rr.Body, emptyDirectictiveErrorMsg)
+			})
+
 		})
 
 		Context("Without an identity header or pre shared key", func() {


### PR DESCRIPTION
Restricts the sending of empty strings with the `directive` field in the `/message` endpoint.