### PR TITLE
Phase 1 handle out of order online messages

### DIFF
--- a/db/migrations/000004_add_message_id_and_message_sent_column.down.sql
+++ b/db/migrations/000004_add_message_id_and_message_sent_column.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE connections
+    DROP COLUMN IF EXISTS message_id;
+ALTER TABLE connections
+    DROP COLUMN IF EXISTS message_sent;

--- a/db/migrations/000004_add_message_id_and_message_sent_column.up.sql
+++ b/db/migrations/000004_add_message_id_and_message_sent_column.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE connections
+    ADD message_id varchar(40);
+ALTER TABLE connections
+    ADD message_sent timestamptz NOT NULL DEFAULT NOW();

--- a/internal/cloud_connector/message_handlers_test.go
+++ b/internal/cloud_connector/message_handlers_test.go
@@ -1,0 +1,199 @@
+package cloud_connector
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/RedHatInsights/cloud-connector/internal/cloud_connector/protocol"
+	"github.com/RedHatInsights/cloud-connector/internal/config"
+	"github.com/RedHatInsights/cloud-connector/internal/connection_repository"
+	"github.com/RedHatInsights/cloud-connector/internal/controller"
+	"github.com/RedHatInsights/cloud-connector/internal/domain"
+	"github.com/RedHatInsights/cloud-connector/internal/mqtt"
+	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
+
+	MQTT "github.com/eclipse/paho.mqtt.golang"
+)
+
+func init() {
+	logger.InitLogger()
+}
+
+type mockConnectionRegistrar struct {
+	clients map[domain.ClientID]domain.ConnectorClientState
+}
+
+func (mcr *mockConnectionRegistrar) Register(ctx context.Context, rhcClient domain.ConnectorClientState) (connection_repository.RegistrationResults, error) {
+	mcr.clients[rhcClient.ClientID] = rhcClient
+	return connection_repository.NewConnection, nil
+}
+
+func (mcr *mockConnectionRegistrar) Unregister(ctx context.Context, clientID domain.ClientID) {
+	return
+}
+
+func (mcr *mockConnectionRegistrar) FindConnectionByClientID(ctx context.Context, clientID domain.ClientID) (domain.ConnectorClientState, error) {
+	return mcr.clients[clientID], nil
+}
+
+type mockAccountIdResolver struct {
+	accounts map[domain.ClientID]domain.AccountID
+}
+
+func (mar *mockAccountIdResolver) MapClientIdToAccountId(ctx context.Context, clientID domain.ClientID) (domain.Identity, domain.AccountID, error) {
+	return domain.Identity("1111"), domain.AccountID("000111"), nil
+}
+
+func TestHandleOnlineMessagesNoExistingConnection(t *testing.T) {
+
+	var mqttClient MQTT.Client
+	var clientID domain.ClientID = "1234"
+	var cfg config.Config
+	var topicBuilder mqtt.TopicBuilder
+	var accountResolver = &mockAccountIdResolver{}
+	var connectionRegistrar = &mockConnectionRegistrar{
+		clients: make(map[domain.ClientID]domain.ConnectorClientState),
+	}
+	var connectedClientRecorder controller.ConnectedClientRecorder
+	var sourcesRecorder controller.SourcesRecorder
+
+	incomingMessage := buildOnlineMessage(t, "56789", time.Now())
+
+	err := handleOnlineMessage(mqttClient, clientID, incomingMessage, &cfg, &topicBuilder, accountResolver, connectionRegistrar, connectedClientRecorder, sourcesRecorder)
+
+	if err != nil {
+		t.Fatal("handleOnlineMessage should not have returned an error")
+	}
+
+	recordedConnectionState, err := connectionRegistrar.FindConnectionByClientID(context.Background(), clientID)
+
+	if recordedConnectionState.MessageMetadata.LatestMessageID != incomingMessage.MessageID {
+		t.Error("incoming messages does not appear to have been stored")
+	}
+}
+
+func TestHandleOnlineMessagesUpdateExistingConnection(t *testing.T) {
+
+	var mqttClient MQTT.Client
+	var clientID domain.ClientID = "1234"
+	var cfg config.Config
+	var topicBuilder mqtt.TopicBuilder
+	var accountResolver = &mockAccountIdResolver{}
+	var connectionRegistrar = &mockConnectionRegistrar{
+		clients: make(map[domain.ClientID]domain.ConnectorClientState),
+	}
+	var connectedClientRecorder controller.ConnectedClientRecorder
+	var sourcesRecorder controller.SourcesRecorder
+
+	var connectionState = domain.ConnectorClientState{
+		Account:  "000111",
+		ClientID: clientID,
+		MessageMetadata: domain.MessageMetadata{
+			LatestMessageID: "12345",
+			LatestTimestamp: time.Now().Add(-2 * time.Second),
+		},
+	}
+
+	if _, err := connectionRegistrar.Register(context.TODO(), connectionState); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedMessageID := "56789"
+	expecteMessageSentTime := time.Now()
+
+	incomingMessage := buildOnlineMessage(t, expectedMessageID, expecteMessageSentTime)
+
+	err := handleOnlineMessage(mqttClient, clientID, incomingMessage, &cfg, &topicBuilder, accountResolver, connectionRegistrar, connectedClientRecorder, sourcesRecorder)
+
+	if err != nil {
+		t.Fatal("handleOnlineMessage should not have returned an error")
+	}
+
+	recordedConnectionState, err := connectionRegistrar.FindConnectionByClientID(context.Background(), clientID)
+
+	if recordedConnectionState.MessageMetadata.LatestMessageID != incomingMessage.MessageID {
+		t.Error("incoming messages does not appear to have been stored")
+	}
+
+	if recordedConnectionState.MessageMetadata.LatestTimestamp != incomingMessage.Sent {
+		t.Error("incoming messages does not appear to have been stored")
+	}
+
+}
+
+func TestHandleDuplicateAndOldOnlineMessages(t *testing.T) {
+
+	var mqttClient MQTT.Client
+	var clientID domain.ClientID = "1234"
+	var cfg config.Config
+	var topicBuilder mqtt.TopicBuilder
+	var accountResolver = &mockAccountIdResolver{}
+	var connectedClientRecorder controller.ConnectedClientRecorder
+	var sourcesRecorder controller.SourcesRecorder
+
+	now := time.Now()
+
+	testCases := []struct {
+		testCaseName      string
+		currentMessageID  string
+		currentSentTime   time.Time
+		incomingMessageID string
+		incomingSentTime  time.Time
+		expectedError     error
+	}{
+		{"duplicate", "1234-56789", now, "1234-56789", now, errDuplicateOrOldMQTTMessage},
+		{"old message", "1234-56789", now, "1234-98765", now.Add(-2 * time.Second), errDuplicateOrOldMQTTMessage},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testCaseName, func(t *testing.T) {
+
+			var connectionRegistrar = &mockConnectionRegistrar{
+				clients: make(map[domain.ClientID]domain.ConnectorClientState),
+			}
+
+			var connectionState = domain.ConnectorClientState{
+				Account:  "000111",
+				ClientID: clientID,
+				MessageMetadata: domain.MessageMetadata{
+					LatestMessageID: tc.currentMessageID,
+					LatestTimestamp: tc.currentSentTime,
+				},
+			}
+
+			if _, err := connectionRegistrar.Register(context.TODO(), connectionState); err != nil {
+				t.Fatal(err)
+			}
+
+			incomingMessage := buildOnlineMessage(t, tc.incomingMessageID, tc.incomingSentTime)
+
+			err := handleOnlineMessage(mqttClient, clientID, incomingMessage, &cfg, &topicBuilder, accountResolver, connectionRegistrar, connectedClientRecorder, sourcesRecorder)
+
+			if err != tc.expectedError {
+				t.Fatal("handleOnlineMesssage did not return the expected error!")
+			}
+
+		})
+	}
+}
+
+func buildOnlineMessage(t *testing.T, messageID string, sentTime time.Time) protocol.ControlMessage {
+	var connectionStatusPayload = "{\"state\":\"online\"}"
+	var content map[string]interface{}
+
+	if err := json.Unmarshal([]byte(connectionStatusPayload), &content); err != nil {
+		t.Fatal(err)
+	}
+
+	var incomingMessage = protocol.ControlMessage{
+		MessageType: "connection-status",
+		MessageID:   messageID,
+		Version:     1,
+		Sent:        sentTime,
+		Content:     content,
+	}
+
+	return incomingMessage
+}

--- a/internal/connection_repository/types.go
+++ b/internal/connection_repository/types.go
@@ -17,6 +17,7 @@ const (
 type ConnectionRegistrar interface {
 	Register(context.Context, domain.ConnectorClientState) (RegistrationResults, error)
 	Unregister(context.Context, domain.ClientID)
+	FindConnectionByClientID(context.Context, domain.ClientID) (domain.ConnectorClientState, error)
 }
 
 type ConnectionLocator interface {

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -1,5 +1,9 @@
 package domain
 
+import (
+	"time"
+)
+
 type Identity string
 
 type ClientID string
@@ -19,10 +23,16 @@ type Dispatchers interface{}
 type CanonicalFacts interface{}
 type Tags interface{}
 
+type MessageMetadata struct {
+	LatestMessageID string
+	LatestTimestamp time.Time
+}
+
 type ConnectorClientState struct {
-	Account        AccountID
-	ClientID       ClientID
-	CanonicalFacts CanonicalFacts
-	Dispatchers    Dispatchers
-	Tags           Tags
+	Account         AccountID
+	ClientID        ClientID
+	CanonicalFacts  CanonicalFacts
+	Dispatchers     Dispatchers
+	Tags            Tags
+	MessageMetadata MessageMetadata
 }

--- a/internal/platform/db/connection.go
+++ b/internal/platform/db/connection.go
@@ -12,7 +12,7 @@ import (
 )
 
 func initializePostgresConnection(cfg *config.Config) (*sql.DB, error) {
-	psqlConnectionInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s",
+	psqlConnectionInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s TimeZone=UTC",
 		cfg.ConnectionDatabaseHost,
 		cfg.ConnectionDatabasePort,
 		cfg.ConnectionDatabaseUser,


### PR DESCRIPTION
This is a phase 1 (crawl approach) to handling duplicate and out of order online messages.  With this approach, I am storing the _sent_ time and _message_id_ of the latest recorded online message.  With each online message received, the stored _message_id_ and _sent_ time are compared.  If the stored _message_id_ matches the incoming _message_id_, then the message is a duplicate and its discarded.  If the _sent_ time of the incoming message is before the stored _sent_ time, then the message is an old message and its discarded.

Right now, the message id and message sent timestamp is stored as field in the connection table.  The other option is to split this data out to a different table.  I'm not sure about the best approach.  Should the message metadata be stored in a different table?

Better names for the new db fields??

There is too much duplication in the tests, but its a start.  I'd like to refactor that later on.

Testing notes:
- existing connections, run db upgrade, have existing connection send another online connection-status message...make sure latest message is recorded
- no existing connection...make sure message is recorded
- send duplicate online messages...make sure message is ignored
- send old online messages...make sure message is ignored