### PR TITLE
Modifying the management endpoint to require turnpike based authentication

### DIFF
--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -45,7 +45,8 @@ func (s *ManagementServer) Routes() {
 	securedSubRouter := s.router.PathPrefix(pathPrefix).Subrouter()
 	securedSubRouter.Use(logger.AccessLoggerMiddleware,
 		mmw.RecordHTTPMetrics,
-		amw.Authenticate)
+		amw.Authenticate,
+		middlewares.RequireTurnpikeAuthentication)
 
 	securedSubRouter.HandleFunc("", s.handleConnectionListing()).Methods(http.MethodGet)
 	securedSubRouter.HandleFunc("/{id:[0-9]+}", s.handleConnectionListingByAccount()).Methods(http.MethodGet)

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -42,7 +42,7 @@ func (s *ManagementServer) Routes() {
 	amw := &middlewares.AuthMiddleware{Secrets: s.config.ServiceToServiceCredentials,
 		IdentityAuth: func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				identity.EnforceIdentity(middlewares.RequireTurnpikeAuthentication(next)).ServeHTTP(w, r)
+				identity.EnforceIdentity(middlewares.EnforceTurnpikeAuthentication(next)).ServeHTTP(w, r)
 				return
 			})
 		},

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Management", func() {
 		ms = NewManagementServer(connectionManager, apiMux, URL_BASE_PATH, cfg)
 		ms.Routes()
 
-		identity := `{ "identity": {"account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`
+		identity := `{ "identity": {"account_number": "540155", "type": "Associate", "internal": { "org_id": "1979710" } } }`
 		validIdentityHeader = base64.StdEncoding.EncodeToString([]byte(identity))
 	})
 

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"github.com/RedHatInsights/cloud-connector/internal/config"
@@ -23,6 +24,7 @@ const (
 	CONNECTION_LIST_ENDPOINT       = URL_BASE_PATH + "/connection"
 	CONNECTION_STATUS_ENDPOINT     = URL_BASE_PATH + "/connection/status"
 	CONNECTION_DISCONNECT_ENDPOINT = URL_BASE_PATH + "/connection/disconnect"
+	CONNECTION_PING_ENDPOINT       = URL_BASE_PATH + "/connection/ping"
 
 	CONNECTED_ACCOUNT_NUMBER = "1234"
 	CONNECTED_NODE_ID        = "345"
@@ -47,6 +49,7 @@ var _ = Describe("Management", func() {
 	BeforeEach(func() {
 		apiMux := mux.NewRouter()
 		cfg := config.GetConfig()
+		cfg.ServiceToServiceCredentials["test_client_1"] = "12345"
 		connectionManager := NewMockConnectionManager()
 		connectorClient := domain.ConnectorClientState{Account: CONNECTED_ACCOUNT_NUMBER, ClientID: CONNECTED_NODE_ID}
 		connectionManager.Register(context.TODO(), connectorClient)
@@ -483,5 +486,42 @@ var _ = Describe("Management", func() {
 		})
 
 	})
+
+	DescribeTable("Connecting to the connection/ping endpoint",
+		func(expectedStatusCode int, headers map[string]string) {
+
+			postBody := createConnectionStatusPostBody(CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID)
+
+			req, err := http.NewRequest("POST", CONNECTION_PING_ENDPOINT, postBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			for k, v := range headers {
+				req.Header.Add(k, v)
+			}
+
+			rr := httptest.NewRecorder()
+
+			ms.router.ServeHTTP(rr, req)
+
+			Expect(rr.Code).To(Equal(expectedStatusCode))
+		},
+
+		Entry("authenticated internal user",
+			http.StatusOK,
+			map[string]string{IDENTITY_HEADER_NAME: buildIdentityHeader("540155", "Associate")}),
+		Entry("authenticated user",
+			http.StatusUnauthorized,
+			map[string]string{IDENTITY_HEADER_NAME: buildIdentityHeader("540155", "User")}),
+		Entry("valid psk",
+			http.StatusOK,
+			map[string]string{TOKEN_HEADER_CLIENT_NAME: "test_client_1",
+				TOKEN_HEADER_ACCOUNT_NAME: "0000001",
+				TOKEN_HEADER_PSK_NAME:     "12345"}),
+		Entry("invalid psk",
+			http.StatusUnauthorized,
+			map[string]string{TOKEN_HEADER_CLIENT_NAME: "test_client_1",
+				TOKEN_HEADER_ACCOUNT_NAME: "0000001",
+				TOKEN_HEADER_PSK_NAME:     "wrong"}),
+	)
 
 })

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -54,8 +53,7 @@ var _ = Describe("Management", func() {
 		ms = NewManagementServer(connectionManager, apiMux, URL_BASE_PATH, cfg)
 		ms.Routes()
 
-		identity := `{ "identity": {"account_number": "540155", "type": "Associate", "internal": { "org_id": "1979710" } } }`
-		validIdentityHeader = base64.StdEncoding.EncodeToString([]byte(identity))
+		validIdentityHeader = buildIdentityHeader("540155", "Associate")
 	})
 
 	Describe("Connecting to the connection/status endpoint", func() {

--- a/internal/controller/api/message_receiver.go
+++ b/internal/controller/api/message_receiver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/RedHatInsights/cloud-connector/internal/domain"
 	"github.com/RedHatInsights/cloud-connector/internal/middlewares"
 	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/redhatinsights/platform-go-middlewares/request_id"
 
 	"github.com/gorilla/mux"
@@ -39,7 +40,7 @@ func NewMessageReceiver(cm connection_repository.ConnectionLocator, r *mux.Route
 
 func (jr *MessageReceiver) Routes() {
 	mmw := &middlewares.MetricsMiddleware{}
-	amw := &middlewares.AuthMiddleware{Secrets: jr.config.ServiceToServiceCredentials}
+	amw := &middlewares.AuthMiddleware{Secrets: jr.config.ServiceToServiceCredentials, IdentityAuth: identity.EnforceIdentity}
 
 	securedSubRouter := jr.router.PathPrefix(jr.urlPrefix).Subrouter()
 	securedSubRouter.Use(logger.AccessLoggerMiddleware,

--- a/internal/controller/api/message_receiver_test.go
+++ b/internal/controller/api/message_receiver_test.go
@@ -461,7 +461,7 @@ var _ = Describe("MessageReceiver", func() {
 
 func buildIdentityHeader(account domain.AccountID) string {
 	identityJson := fmt.Sprintf(
-		"{ \"identity\": {\"account_number\": \"%s\", \"type\": \"User\", \"internal\": { \"org_id\": \"1979710\" } } }",
+		"{ \"identity\": {\"account_number\": \"%s\", \"type\": \"Associate\", \"internal\": { \"org_id\": \"1979710\" } } }",
 		account)
 	return base64.StdEncoding.EncodeToString([]byte(identityJson))
 }

--- a/internal/controller/api/message_receiver_test.go
+++ b/internal/controller/api/message_receiver_test.go
@@ -3,10 +3,8 @@ package api
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -159,7 +157,7 @@ var _ = Describe("MessageReceiver", func() {
 		jr = NewMessageReceiver(connectionManager, apiMux, URL_BASE_PATH, cfg)
 		jr.Routes()
 
-		validIdentityHeader = buildIdentityHeader(account)
+		validIdentityHeader = buildIdentityHeader(account, "Associate")
 	})
 
 	AfterEach(func() {
@@ -219,7 +217,7 @@ var _ = Describe("MessageReceiver", func() {
 				req, err := http.NewRequest("POST", MESSAGE_ENDPOINT, strings.NewReader(postBody))
 				Expect(err).NotTo(HaveOccurred())
 
-				validIdentityHeader = buildIdentityHeader("1234-not-here")
+				validIdentityHeader = buildIdentityHeader("1234-not-here", "Associate")
 
 				req.Header.Add(IDENTITY_HEADER_NAME, validIdentityHeader)
 
@@ -317,7 +315,7 @@ var _ = Describe("MessageReceiver", func() {
 				req, err := http.NewRequest("POST", MESSAGE_ENDPOINT, strings.NewReader(postBody))
 				Expect(err).NotTo(HaveOccurred())
 
-				validIdentityHeader = buildIdentityHeader("4321")
+				validIdentityHeader = buildIdentityHeader("4321", "Associate")
 
 				req.Header.Add(IDENTITY_HEADER_NAME, validIdentityHeader)
 
@@ -458,13 +456,6 @@ var _ = Describe("MessageReceiver", func() {
 
 	})
 })
-
-func buildIdentityHeader(account domain.AccountID) string {
-	identityJson := fmt.Sprintf(
-		"{ \"identity\": {\"account_number\": \"%s\", \"type\": \"Associate\", \"internal\": { \"org_id\": \"1979710\" } } }",
-		account)
-	return base64.StdEncoding.EncodeToString([]byte(identityJson))
-}
 
 func verifyErrorResponse(body *bytes.Buffer, expectedDetail string) {
 	var errorResponse errorResponse

--- a/internal/controller/api/pagination_test.go
+++ b/internal/controller/api/pagination_test.go
@@ -200,7 +200,7 @@ func testSetup(connectionCount int) (*ManagementServer, string) {
 	managementServer := NewManagementServer(connectionManager, apiMux, URL_BASE_PATH, cfg)
 	managementServer.Routes()
 
-	identity := `{ "identity": {"account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`
+	identity := `{ "identity": {"account_number": "540155", "type": "Associate", "internal": { "org_id": "1979710" } } }`
 	identityHeader := base64.StdEncoding.EncodeToString([]byte(identity))
 
 	return managementServer, identityHeader

--- a/internal/controller/api/pagination_test.go
+++ b/internal/controller/api/pagination_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -200,10 +199,7 @@ func testSetup(connectionCount int) (*ManagementServer, string) {
 	managementServer := NewManagementServer(connectionManager, apiMux, URL_BASE_PATH, cfg)
 	managementServer.Routes()
 
-	identity := `{ "identity": {"account_number": "540155", "type": "Associate", "internal": { "org_id": "1979710" } } }`
-	identityHeader := base64.StdEncoding.EncodeToString([]byte(identity))
-
-	return managementServer, identityHeader
+	return managementServer, buildIdentityHeader("540155", "Associate")
 }
 
 func runTest(endpoint string, managementServer *ManagementServer, identityHeader string, expectedResponse paginatedResponse) {

--- a/internal/controller/api/test_utils.go
+++ b/internal/controller/api/test_utils.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/RedHatInsights/cloud-connector/internal/domain"
+)
+
+func buildIdentityHeader(account domain.AccountID, identityType string) string {
+	identityJson := fmt.Sprintf(
+		"{ \"identity\": {\"account_number\": \"%s\", \"type\": \"%s\", \"internal\": { \"org_id\": \"1979710\" } } }",
+		account,
+		identityType)
+	return base64.StdEncoding.EncodeToString([]byte(identityJson))
+}

--- a/internal/middlewares/auth.go
+++ b/internal/middlewares/auth.go
@@ -99,7 +99,8 @@ func (scv *serviceCredentialsValidator) validate(sc *serviceCredentials) error {
 
 // AuthMiddleware allows the passage of parameters into the Authenticate middleware
 type AuthMiddleware struct {
-	Secrets map[string]interface{}
+	Secrets      map[string]interface{}
+	IdentityAuth func(http.Handler) http.Handler
 }
 
 // Authenticate determines which authentication method should be used, and delegates identity header
@@ -107,7 +108,7 @@ type AuthMiddleware struct {
 func (amw *AuthMiddleware) Authenticate(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get(identityHeader) != "" { // identity header auth
-			identity.EnforceIdentity(next).ServeHTTP(w, r)
+			amw.IdentityAuth(next).ServeHTTP(w, r)
 		} else { // token auth
 			sr, err := newServiceCredentials(
 				r.Header.Get(PSKClientIdHeader),

--- a/internal/middlewares/auth_test.go
+++ b/internal/middlewares/auth_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/RedHatInsights/cloud-connector/internal/middlewares"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 const (
@@ -49,7 +50,8 @@ var _ = Describe("Auth", func() {
 	BeforeEach(func() {
 		knownSecrets := make(map[string]interface{})
 		knownSecrets["test_client_1"] = "12345"
-		amw = &middlewares.AuthMiddleware{Secrets: knownSecrets}
+		amw = &middlewares.AuthMiddleware{Secrets: knownSecrets, IdentityAuth: identity.EnforceIdentity}
+
 		r, err := http.NewRequest("GET", "/api/cloud-connector/v1/job", nil)
 		if err != nil {
 			panic("Test error unable to get new request")

--- a/internal/middlewares/turnpike_auth.go
+++ b/internal/middlewares/turnpike_auth.go
@@ -9,9 +9,9 @@ import (
 	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
 )
 
-// RequireTurnpikeAuthentication requires that the request be authenticated against Turnpike
-// This middlware should be installed after the RedHatInsights Identity middleware
-func RequireTurnpikeAuthentication(next http.Handler) http.Handler {
+// EnforceTurnpikeAuthentication requires that the request be authenticated against Turnpike
+// This middlware must be installed after the RedHatInsights Identity middleware
+func EnforceTurnpikeAuthentication(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		xrhID := identity.Get(r.Context())

--- a/internal/middlewares/turnpike_auth.go
+++ b/internal/middlewares/turnpike_auth.go
@@ -1,7 +1,6 @@
 package middlewares
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/redhatinsights/platform-go-middlewares/identity"
@@ -15,11 +14,10 @@ func EnforceTurnpikeAuthentication(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		xrhID := identity.Get(r.Context())
-		fmt.Println("xrhID: ", xrhID)
 
 		if xrhID.Identity.Type != "Associate" {
 			logger.Log.Debug(authErrorLogHeader + "Invalid identity type")
-			http.Error(w, authErrorMessage, 401)
+			http.Error(w, authErrorMessage, http.StatusUnauthorized)
 			return
 		}
 

--- a/internal/middlewares/turnpike_auth.go
+++ b/internal/middlewares/turnpike_auth.go
@@ -16,7 +16,7 @@ func EnforceTurnpikeAuthentication(next http.Handler) http.Handler {
 		xrhID := identity.Get(r.Context())
 
 		if xrhID.Identity.Type != "Associate" {
-			logger.Log.Debug(authErrorLogHeader + "Invalid identity type")
+			logger.Log.Debug(authErrorLogHeader + "Invalid identity type: " + xrhID.Identity.Type)
 			http.Error(w, authErrorMessage, http.StatusUnauthorized)
 			return
 		}

--- a/internal/middlewares/turnpike_auth.go
+++ b/internal/middlewares/turnpike_auth.go
@@ -1,0 +1,28 @@
+package middlewares
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+
+	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
+)
+
+// RequireTurnpikeAuthentication requires that the request be authenticated against Turnpike
+// This middlware should be installed after the RedHatInsights Identity middleware
+func RequireTurnpikeAuthentication(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		xrhID := identity.Get(r.Context())
+		fmt.Println("xrhID: ", xrhID)
+
+		if xrhID.Identity.Type != "Associate" {
+			logger.Log.Debug(authErrorLogHeader + "Invalid identity type")
+			http.Error(w, authErrorMessage, 401)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/middlewares/turnpike_auth_test.go
+++ b/internal/middlewares/turnpike_auth_test.go
@@ -40,7 +40,7 @@ func TestTurnpikeAuthenticator(t *testing.T) {
 				rw.WriteHeader(200)
 			})
 
-			handler := identity.EnforceIdentity(RequireTurnpikeAuthentication(applicationHandler))
+			handler := identity.EnforceIdentity(EnforceTurnpikeAuthentication(applicationHandler))
 
 			handler.ServeHTTP(rr, req)
 

--- a/internal/middlewares/turnpike_auth_test.go
+++ b/internal/middlewares/turnpike_auth_test.go
@@ -1,10 +1,10 @@
 package middlewares
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
@@ -19,29 +19,30 @@ func TestTurnpikeAuthenticator(t *testing.T) {
 
 	testCases := []struct {
 		IdentityType       string
+		IdentityHeader     string
 		ExpectedStatusCode int
 	}{
-		{"Associate", 200},
-		{"User", 401},
+		{"Associate", "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMiIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9LCAidHlwZSI6ICJBc3NvY2lhdGUifX0=", 200},
+		{"User", "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMiIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9LCAidHlwZSI6ICJiYXNpYyJ9fQ==", 401},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("subtest identity type %s", tc.IdentityType), func(t *testing.T) {
 
-			var req http.Request
-			rr := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, "/doesntmatter", strings.NewReader("doesntmatter"))
 
-			var xrhID identity.XRHID
-			xrhID.Identity.Type = tc.IdentityType
+			req.Header = make(http.Header)
+			req.Header.Add("x-rh-identity", tc.IdentityHeader)
+
+			rr := httptest.NewRecorder()
 
 			applicationHandler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(200)
 			})
 
-			handler := RequireTurnpikeAuthentication(applicationHandler)
+			handler := identity.EnforceIdentity(RequireTurnpikeAuthentication(applicationHandler))
 
-			ctx := context.WithValue(req.Context(), identity.Key, xrhID)
-			handler.ServeHTTP(rr, req.WithContext(ctx))
+			handler.ServeHTTP(rr, req)
 
 			if rr.Code != tc.ExpectedStatusCode {
 				t.Fatalf("Invalid status code - actual: %d, expected: %d", rr.Code, tc.ExpectedStatusCode)

--- a/internal/middlewares/turnpike_auth_test.go
+++ b/internal/middlewares/turnpike_auth_test.go
@@ -22,8 +22,8 @@ func TestTurnpikeAuthenticator(t *testing.T) {
 		IdentityHeader     string
 		ExpectedStatusCode int
 	}{
-		{"Associate", "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMiIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9LCAidHlwZSI6ICJBc3NvY2lhdGUifX0=", 200},
-		{"User", "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMiIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9LCAidHlwZSI6ICJiYXNpYyJ9fQ==", 401},
+		{"Associate", "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMiIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9LCAidHlwZSI6ICJBc3NvY2lhdGUifX0=", http.StatusOK},
+		{"User", "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMiIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9LCAidHlwZSI6ICJiYXNpYyJ9fQ==", http.StatusUnauthorized},
 	}
 
 	for _, tc := range testCases {

--- a/internal/middlewares/turnpike_auth_test.go
+++ b/internal/middlewares/turnpike_auth_test.go
@@ -1,0 +1,57 @@
+package middlewares
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+func init() {
+	logger.InitLogger()
+}
+
+func TestTurnpikeAuthenticatorAssociate(t *testing.T) {
+	var req http.Request
+	rr := httptest.NewRecorder()
+
+	var xrhID identity.XRHID
+	xrhID.Identity.Type = "Associate"
+
+	applicationHandler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(200)
+	})
+
+	handler := RequireTurnpikeAuthentication(applicationHandler)
+
+	ctx := context.WithValue(req.Context(), identity.Key, xrhID)
+	handler.ServeHTTP(rr, req.WithContext(ctx))
+
+	if rr.Code != 200 {
+		t.Fatal("Code != 200")
+	}
+}
+
+func TestTurnpikeAuthenticatorUser(t *testing.T) {
+	var req http.Request
+	rr := httptest.NewRecorder()
+
+	var xrhID identity.XRHID
+	xrhID.Identity.Type = "User"
+
+	applicationHandler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(200)
+	})
+
+	handler := RequireTurnpikeAuthentication(applicationHandler)
+
+	ctx := context.WithValue(req.Context(), identity.Key, xrhID)
+	handler.ServeHTTP(rr, req.WithContext(ctx))
+
+	if rr.Code != 401 {
+		t.Fatal("Code != 401")
+	}
+}


### PR DESCRIPTION
Modify the main authentication middleware to take a high-order function that handles the x-rh-identity based authentication.  This PR wraps the existing x-rh-identity authentication function with a function that enforces the Turnpike based authentication.

This approach allows for separation of concerns (the existing identity header authenticator only handles looking for the identity header, parsing the identity header) while providing flexibility to add new checks (Turnpike based authentication) to different endpoints.
