### PR TITLE
Positive, integer reconnect delay [RHCLOUD-13033] and [RHCLOUD-13030]

### DIFF
--- a/internal/controller/api/api.spec.json
+++ b/internal/controller/api/api.spec.json
@@ -512,7 +512,8 @@
             "type": "string"
           },
           "delay": {
-            "type": "number"
+            "type": "integer",
+            "minimum": 0
           },
           "message": {
             "type": "string"

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -17,8 +17,11 @@ import (
 )
 
 const (
-	CONNECTED_STATUS    = "connected"
-	DISCONNECTED_STATUS = "disconnected"
+	CONNECTED_STATUS     = "connected"
+	DISCONNECTED_STATUS  = "disconnected"
+	DECODE_ERROR         = "Unable to process json input"
+	NEGATIVE_DELAY_ERROR = "Delay field cannot be negative"
+	PING_ERROR           = "Ping failed"
 )
 
 type ManagementServer struct {
@@ -99,7 +102,7 @@ func (s *ManagementServer) handleDisconnect() http.HandlerFunc {
 		var disconnectReq disconnectRequest
 
 		if err := decodeJSON(body, &disconnectReq); err != nil {
-			errorResponse := errorResponse{Title: "Unable to process json input",
+			errorResponse := errorResponse{Title: DECODE_ERROR,
 				Status: http.StatusBadRequest,
 				Detail: err.Error()}
 			writeJSONResponse(w, errorResponse.Status, errorResponse)
@@ -148,7 +151,7 @@ func (s *ManagementServer) handleReconnect() http.HandlerFunc {
 		var reconnectReq reconnectRequest
 
 		if err := decodeJSON(body, &reconnectReq); err != nil {
-			errorResponse := errorResponse{Title: "Unable to process json input",
+			errorResponse := errorResponse{Title: DECODE_ERROR,
 				Status: http.StatusBadRequest,
 				Detail: err.Error()}
 			writeJSONResponse(w, errorResponse.Status, errorResponse)
@@ -156,7 +159,7 @@ func (s *ManagementServer) handleReconnect() http.HandlerFunc {
 		}
 
 		if reconnectReq.Delay < 0 {
-			errMsg := "Delay field cannot be negative"
+			errMsg := NEGATIVE_DELAY_ERROR
 			logger.Info(errMsg)
 			errorResponse := errorResponse{Title: errMsg,
 				Status: http.StatusBadRequest,
@@ -200,7 +203,7 @@ func (s *ManagementServer) handleConnectionStatus() http.HandlerFunc {
 		var connID connectionID
 
 		if err := decodeJSON(body, &connID); err != nil {
-			errorResponse := errorResponse{Title: "Unable to process json input",
+			errorResponse := errorResponse{Title: DECODE_ERROR,
 				Status: http.StatusBadRequest,
 				Detail: err.Error()}
 			writeJSONResponse(w, errorResponse.Status, errorResponse)
@@ -372,7 +375,7 @@ func (s *ManagementServer) handleConnectionPing() http.HandlerFunc {
 		var connID connectionID
 
 		if err := decodeJSON(body, &connID); err != nil {
-			errorResponse := errorResponse{Title: "Unable to process json input",
+			errorResponse := errorResponse{Title: DECODE_ERROR,
 				Status: http.StatusBadRequest,
 				Detail: err.Error()}
 			writeJSONResponse(w, errorResponse.Status, errorResponse)
@@ -394,7 +397,7 @@ func (s *ManagementServer) handleConnectionPing() http.HandlerFunc {
 		err := client.Ping(req.Context())
 
 		if err != nil {
-			errorResponse := errorResponse{Title: "Ping failed",
+			errorResponse := errorResponse{Title: PING_ERROR,
 				Status: http.StatusBadRequest,
 				Detail: err.Error()}
 			writeJSONResponse(w, errorResponse.Status, errorResponse)

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -155,6 +155,16 @@ func (s *ManagementServer) handleReconnect() http.HandlerFunc {
 			return
 		}
 
+		if reconnectReq.Delay < 0 {
+			errMsg := "Delay field cannot be negative"
+			logger.Info(errMsg)
+			errorResponse := errorResponse{Title: errMsg,
+				Status: http.StatusBadRequest,
+				Detail: errMsg}
+			writeJSONResponse(w, errorResponse.Status, errorResponse)
+			return
+		}
+
 		client := s.connectionMgr.GetConnection(req.Context(), reconnectReq.Account, reconnectReq.NodeID)
 		if client == nil {
 			errMsg := fmt.Sprintf("No connection found for node (%s:%s)", reconnectReq.Account, reconnectReq.NodeID)

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -512,9 +512,9 @@ var _ = Describe("Management", func() {
 
 				var actualResponse errorResponse
 				var expectedResponse = errorResponse{
-					Title:  "Delay field cannot be negative",
+					Title:  NEGATIVE_DELAY_ERROR,
 					Status: http.StatusBadRequest,
-					Detail: "Delay field cannot be negative",
+					Detail: NEGATIVE_DELAY_ERROR,
 				}
 
 				json.Unmarshal(rr.Body.Bytes(), &actualResponse)

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -513,7 +513,7 @@ var _ = Describe("Management", func() {
 				var actualResponse errorResponse
 				var expectedResponse = errorResponse{
 					Title:  "Delay field cannot be negative",
-					Status: 400,
+					Status: http.StatusBadRequest,
 					Detail: "Delay field cannot be negative",
 				}
 

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -497,7 +497,7 @@ var _ = Describe("Management", func() {
 		Context("With a negative delay", func() {
 			It("Should fail to reconnect", func() {
 
-				postBody := createConnectionReconnectPostBody(CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID, "-1", "something bad happened")
+				postBody := createConnectionReconnectPostBody(CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID, "-1", "requesting to reconnect")
 
 				req, err := http.NewRequest("POST", CONNECTION_RECONNECT_ENDPOINT, postBody)
 				Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -40,8 +40,8 @@ func createConnectionStatusPostBody(account_number string, node_id string) io.Re
 	return strings.NewReader(jsonString)
 }
 
-func createConnectionReconnectPostBody(account_number string, node_id string, delay string, message string) io.Reader {
-	jsonString := fmt.Sprintf("{\"account\": \"%s\", \"node_id\": \"%s\", \"delay\": %s, \"message\": \"%s\"}", account_number, node_id, delay, message)
+func createConnectionReconnectPostBody(account_number string, node_id string, delay int, message string) io.Reader {
+	jsonString := fmt.Sprintf("{\"account\": \"%s\", \"node_id\": \"%s\", \"delay\": %d, \"message\": \"%s\"}", account_number, node_id, delay, message)
 	return strings.NewReader(jsonString)
 }
 
@@ -497,7 +497,7 @@ var _ = Describe("Management", func() {
 		Context("With a negative delay", func() {
 			It("Should fail to reconnect", func() {
 
-				postBody := createConnectionReconnectPostBody(CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID, "-1", "requesting to reconnect")
+				postBody := createConnectionReconnectPostBody(CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID, -1, "requesting to reconnect")
 
 				req, err := http.NewRequest("POST", CONNECTION_RECONNECT_ENDPOINT, postBody)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Updated the reconnect endpoint to return an error if passed a negative or decimal delay parameter. 