### PR TITLE
Add org_id to logs [RHCLOUD-17729]

### DIFF
--- a/cmd/cloud-connector/inventory_stale_timestamp_updater.go
+++ b/cmd/cloud-connector/inventory_stale_timestamp_updater.go
@@ -64,20 +64,20 @@ func startInventoryStaleTimestampUpdater() {
 	connection_repository.ProcessStaleConnections(context.TODO(), databaseConn, sqlTimeout, tooOldIfBeforeThisTime, chunkSize,
 		func(ctx context.Context, rhcClient domain.ConnectorClientState) error {
 
-			log := logger.Log.WithFields(logrus.Fields{"client_id": rhcClient.ClientID, "account": rhcClient.Account})
+			log := logger.Log.WithFields(logrus.Fields{"client_id": rhcClient.ClientID, "account": rhcClient.Account, "org_id": rhcClient.OrgID})
 
 			log.Debug("Processing stale connection")
 
 			identity, _, _, err := accountResolver.MapClientIdToAccountId(ctx, rhcClient.ClientID)
 			if err != nil {
 				// FIXME: Send disconnect here??  Need to determine the type of failure!
-				logger.LogErrorWithAccountAndClientId("Unable to retrieve identity for connection", err, rhcClient.Account, rhcClient.ClientID)
+				logger.LogErrorWithAccountAndClientId("Unable to retrieve identity for connection", err, rhcClient.Account, rhcClient.OrgID, rhcClient.ClientID)
 				return err
 			}
 
 			err = connectedClientRecorder.RecordConnectedClient(ctx, identity, rhcClient)
 			if err != nil {
-				logger.LogErrorWithAccountAndClientId("Unable to sent host info to inventory", err, rhcClient.Account, rhcClient.ClientID)
+				logger.LogErrorWithAccountAndClientId("Unable to sent host info to inventory", err, rhcClient.Account, rhcClient.OrgID, rhcClient.ClientID)
 				return err
 			}
 

--- a/internal/connection_repository/sql_connection_locator.go
+++ b/internal/connection_repository/sql_connection_locator.go
@@ -134,18 +134,14 @@ func (scm *SqlConnectionLocator) GetConnectionsByAccount(ctx context.Context, ac
 
 	for rows.Next() {
 		var client_id domain.ClientID
-		var orgIdString string
+		var orgIdString sql.NullString
 		var dispatchersString string
 		if err := rows.Scan(&client_id, &orgIdString, &dispatchersString, &totalConnections); err != nil {
 			logger.LogError("SQL scan failed.  Skipping row.", err)
 			continue
 		}
 
-		var org_id domain.OrgID
-		err = json.Unmarshal([]byte(orgIdString), &org_id)
-		if err != nil {
-			logger.LogErrorWithAccountAndClientId("Unable to marshal org ID from database", err, account, org_id, client_id)
-		}
+		org_id := domain.OrgID(orgIdString.String)
 
 		var dispatchers domain.Dispatchers
 		err = json.Unmarshal([]byte(dispatchersString), &dispatchers)
@@ -203,13 +199,7 @@ func (scm *SqlConnectionLocator) GetAllConnections(ctx context.Context, offset i
 			continue
 		}
 
-		var orgId domain.OrgID
-		if orgIdString.Valid {
-			err = json.Unmarshal([]byte(orgIdString.String), &orgId)
-			if err != nil {
-				logger.LogErrorWithAccountAndClientId("Unable to unmarshal org ID from database", err, account, orgId, clientId)
-			}
-		}
+		orgId := domain.OrgID(orgIdString.String)
 
 		var dispatchers domain.Dispatchers
 		if dispatchersString.Valid {

--- a/internal/connection_repository/sql_connection_locator.go
+++ b/internal/connection_repository/sql_connection_locator.go
@@ -91,13 +91,13 @@ func (scm *SqlConnectionLocator) GetConnection(ctx context.Context, account doma
 	if dispatchersString.Valid {
 		err = json.Unmarshal([]byte(dispatchersString.String), &dispatchers)
 		if err != nil {
-			logger.LogErrorWithAccountAndClientId("Unable to unmarshal dispatchers from database", err, account, client_id)
+			logger.LogErrorWithAccountAndClientId("Unable to unmarshal dispatchers from database", err, account, orgID, client_id)
 		}
 	}
 
 	conn, err = scm.proxyFactory.CreateProxy(ctx, domain.AccountID(account), domain.ClientID(client_id), dispatchers)
 	if err != nil {
-		logger.LogErrorWithAccountAndClientId("Unable to create the proxy", err, account, client_id)
+		logger.LogErrorWithAccountAndClientId("Unable to create the proxy", err, account, orgID, client_id)
 		return nil
 	}
 
@@ -114,7 +114,7 @@ func (scm *SqlConnectionLocator) GetConnectionsByAccount(ctx context.Context, ac
 	connectionsPerAccount := make(map[domain.ClientID]controller.ConnectorClient)
 
 	statement, err := scm.database.Prepare(
-		`SELECT client_id, dispatchers, COUNT(*) OVER() FROM connections
+		`SELECT client_id, org_id, dispatchers, COUNT(*) OVER() FROM connections
             WHERE account = $1
             ORDER BY client_id
             OFFSET $2
@@ -134,8 +134,9 @@ func (scm *SqlConnectionLocator) GetConnectionsByAccount(ctx context.Context, ac
 
 	for rows.Next() {
 		var client_id domain.ClientID
+		var org_id domain.OrgID
 		var dispatchersString string
-		if err := rows.Scan(&client_id, &dispatchersString, &totalConnections); err != nil {
+		if err := rows.Scan(&client_id, &org_id, &dispatchersString, &totalConnections); err != nil {
 			logger.LogError("SQL scan failed.  Skipping row.", err)
 			continue
 		}
@@ -143,12 +144,12 @@ func (scm *SqlConnectionLocator) GetConnectionsByAccount(ctx context.Context, ac
 		var dispatchers domain.Dispatchers
 		err = json.Unmarshal([]byte(dispatchersString), &dispatchers)
 		if err != nil {
-			logger.LogErrorWithAccountAndClientId("Unable to unmarshal dispatchers from database", err, account, client_id)
+			logger.LogErrorWithAccountAndClientId("Unable to unmarshal dispatchers from database", err, account, org_id, client_id)
 		}
 
 		proxy, err := scm.proxyFactory.CreateProxy(ctx, domain.AccountID(account), domain.ClientID(client_id), dispatchers)
 		if err != nil {
-			logger.LogErrorWithAccountAndClientId("Unable to create the proxy.  Skipping row.", err, account, client_id)
+			logger.LogErrorWithAccountAndClientId("Unable to create the proxy.  Skipping row.", err, account, org_id, client_id)
 			continue
 		}
 
@@ -168,7 +169,7 @@ func (scm *SqlConnectionLocator) GetAllConnections(ctx context.Context, offset i
 	connectionMap := make(map[domain.AccountID]map[domain.ClientID]controller.ConnectorClient)
 
 	statement, err := scm.database.Prepare(
-		`SELECT account, client_id, dispatchers, COUNT(*) OVER() FROM connections
+		`SELECT account, org_id, client_id, dispatchers, COUNT(*) OVER() FROM connections
             ORDER BY account, client_id
             OFFSET $1
             LIMIT $2`)
@@ -187,10 +188,11 @@ func (scm *SqlConnectionLocator) GetAllConnections(ctx context.Context, offset i
 
 	for rows.Next() {
 		var account domain.AccountID
+		var orgId domain.OrgID
 		var clientId domain.ClientID
 		var dispatchersString sql.NullString
 
-		if err := rows.Scan(&account, &clientId, &dispatchersString, &totalConnections); err != nil {
+		if err := rows.Scan(&account, &orgId, &clientId, &dispatchersString, &totalConnections); err != nil {
 			logger.LogError("SQL scan failed.  Skipping row.", err)
 			continue
 		}
@@ -199,13 +201,13 @@ func (scm *SqlConnectionLocator) GetAllConnections(ctx context.Context, offset i
 		if dispatchersString.Valid {
 			err = json.Unmarshal([]byte(dispatchersString.String), &dispatchers)
 			if err != nil {
-				logger.LogErrorWithAccountAndClientId("Unable to unmarshal dispatchers from database", err, account, clientId)
+				logger.LogErrorWithAccountAndClientId("Unable to unmarshal dispatchers from database", err, account, orgId, clientId)
 			}
 		}
 
 		proxy, err := scm.proxyFactory.CreateProxy(ctx, domain.AccountID(account), domain.ClientID(clientId), dispatchers)
 		if err != nil {
-			logger.LogErrorWithAccountAndClientId("Unable to create the proxy.  Skipping row.", err, account, clientId)
+			logger.LogErrorWithAccountAndClientId("Unable to create the proxy.  Skipping row.", err, account, orgId, clientId)
 			continue
 		}
 

--- a/internal/connection_repository/stale_connection_locator.go
+++ b/internal/connection_repository/stale_connection_locator.go
@@ -20,7 +20,7 @@ func ProcessStaleConnections(ctx context.Context, databaseConn *sql.DB, sqlTimeo
 	defer cancel()
 
 	statement, err := databaseConn.Prepare(
-		`SELECT account, client_id, canonical_facts, tags FROM connections
+		`SELECT account, org_id, client_id, canonical_facts, tags FROM connections
            WHERE canonical_facts != '{}' AND
              dispatchers ? 'rhc-worker-playbook' AND
              stale_timestamp < $1
@@ -41,11 +41,12 @@ func ProcessStaleConnections(ctx context.Context, databaseConn *sql.DB, sqlTimeo
 
 	for rows.Next() {
 		var account domain.AccountID
+		var orgID domain.OrgID
 		var clientID domain.ClientID
 		var canonicalFactsString sql.NullString
 		var tagsString sql.NullString
 
-		if err := rows.Scan(&account, &clientID, &canonicalFactsString, &tagsString); err != nil {
+		if err := rows.Scan(&account, &orgID, &clientID, &canonicalFactsString, &tagsString); err != nil {
 			logger.LogError("SQL scan failed.  Skipping row.", err)
 			continue
 		}
@@ -54,7 +55,7 @@ func ProcessStaleConnections(ctx context.Context, databaseConn *sql.DB, sqlTimeo
 		if canonicalFactsString.Valid {
 			err = json.Unmarshal([]byte(canonicalFactsString.String), &canonicalFacts)
 			if err != nil {
-				logger.LogErrorWithAccountAndClientId("Unable to parse canonical facts.  Skipping connection.", err, account, clientID)
+				logger.LogErrorWithAccountAndClientId("Unable to parse canonical facts.  Skipping connection.", err, account, orgID, clientID)
 				continue
 			}
 		}
@@ -63,7 +64,7 @@ func ProcessStaleConnections(ctx context.Context, databaseConn *sql.DB, sqlTimeo
 		if tagsString.Valid {
 			err = json.Unmarshal([]byte(tagsString.String), &tags)
 			if err != nil {
-				logger.LogErrorWithAccountAndClientId("Unable to parse tags.  Skipping connection.", err, account, clientID)
+				logger.LogErrorWithAccountAndClientId("Unable to parse tags.  Skipping connection.", err, account, orgID, clientID)
 				continue
 			}
 		}

--- a/internal/connection_repository/stale_connection_locator.go
+++ b/internal/connection_repository/stale_connection_locator.go
@@ -41,7 +41,7 @@ func ProcessStaleConnections(ctx context.Context, databaseConn *sql.DB, sqlTimeo
 
 	for rows.Next() {
 		var account domain.AccountID
-		var orgID domain.OrgID
+		var orgID sql.NullString
 		var clientID domain.ClientID
 		var canonicalFactsString sql.NullString
 		var tagsString sql.NullString
@@ -55,7 +55,7 @@ func ProcessStaleConnections(ctx context.Context, databaseConn *sql.DB, sqlTimeo
 		if canonicalFactsString.Valid {
 			err = json.Unmarshal([]byte(canonicalFactsString.String), &canonicalFacts)
 			if err != nil {
-				logger.LogErrorWithAccountAndClientId("Unable to parse canonical facts.  Skipping connection.", err, account, orgID, clientID)
+				logger.LogErrorWithAccountAndClientId("Unable to parse canonical facts.  Skipping connection.", err, account, domain.OrgID(orgID.String), clientID)
 				continue
 			}
 		}
@@ -64,7 +64,7 @@ func ProcessStaleConnections(ctx context.Context, databaseConn *sql.DB, sqlTimeo
 		if tagsString.Valid {
 			err = json.Unmarshal([]byte(tagsString.String), &tags)
 			if err != nil {
-				logger.LogErrorWithAccountAndClientId("Unable to parse tags.  Skipping connection.", err, account, orgID, clientID)
+				logger.LogErrorWithAccountAndClientId("Unable to parse tags.  Skipping connection.", err, account, domain.OrgID(orgID.String), clientID)
 				continue
 			}
 		}

--- a/internal/controller/account_resolver.go
+++ b/internal/controller/account_resolver.go
@@ -101,6 +101,7 @@ func (bar *BOPAccountIdResolver) MapClientIdToAccountId(ctx context.Context, cli
 	}
 
 	logger.WithFields(logrus.Fields{"account": jsonData.Identity.AccountNumber}).Debug("Located account number for client")
+	logger.WithFields(logrus.Fields{"org_id": jsonData.Identity.Internal.OrgID}).Debug("Located OrgID for client")
 
 	return domain.Identity(resp.Identity), domain.AccountID(jsonData.Identity.AccountNumber), domain.OrgID(jsonData.Identity.Internal.OrgID), nil
 }

--- a/internal/controller/account_resolver.go
+++ b/internal/controller/account_resolver.go
@@ -100,8 +100,7 @@ func (bar *BOPAccountIdResolver) MapClientIdToAccountId(ctx context.Context, cli
 		return "", "", "", err
 	}
 
-	logger.WithFields(logrus.Fields{"account": jsonData.Identity.AccountNumber}).Debug("Located account number for client")
-	logger.WithFields(logrus.Fields{"org_id": jsonData.Identity.Internal.OrgID}).Debug("Located OrgID for client")
+	logger.WithFields(logrus.Fields{"account": jsonData.Identity.AccountNumber, "org_id": jsonData.Identity.Internal.OrgID}).Debug("Located account number and org ID for client")
 
 	return domain.Identity(resp.Identity), domain.AccountID(jsonData.Identity.AccountNumber), domain.OrgID(jsonData.Identity.Internal.OrgID), nil
 }

--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -98,7 +98,6 @@ func (ibccr *InventoryBasedConnectedClientRecorder) RecordConnectedClient(ctx co
 	hostData := cleanupCanonicalFacts(logger, originalHostData)
 
 	hostData["account"] = string(account)
-	hostData["org_id"] = string(orgID)
 	hostData["stale_timestamp"] = staleTimestamp.UTC().Format("2006-01-02T15:04:05Z07:00")
 	hostData["reporter"] = ibccr.ReporterName
 

--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -81,12 +81,14 @@ type InventoryBasedConnectedClientRecorder struct {
 func (ibccr *InventoryBasedConnectedClientRecorder) RecordConnectedClient(ctx context.Context, identity domain.Identity, rhcClient domain.ConnectorClientState) error {
 
 	account := rhcClient.Account
+	orgID := rhcClient.OrgID
 	clientID := rhcClient.ClientID
 
 	requestID, _ := uuid.NewUUID()
 
 	logger := logger.Log.WithFields(logrus.Fields{"request_id": requestID.String(),
 		"account":   account,
+		"org_id":    orgID,
 		"client_id": clientID})
 
 	staleTimestamp := time.Now().Add(ibccr.StaleTimestampOffset)
@@ -96,6 +98,7 @@ func (ibccr *InventoryBasedConnectedClientRecorder) RecordConnectedClient(ctx co
 	hostData := cleanupCanonicalFacts(logger, originalHostData)
 
 	hostData["account"] = string(account)
+	hostData["org_id"] = string(orgID)
 	hostData["stale_timestamp"] = staleTimestamp.UTC().Format("2006-01-02T15:04:05Z07:00")
 	hostData["reporter"] = ibccr.ReporterName
 
@@ -207,7 +210,7 @@ type FakeConnectedClientRecorder struct {
 }
 
 func (fccr *FakeConnectedClientRecorder) RecordConnectedClient(ctx context.Context, identity domain.Identity, rhcClient domain.ConnectorClientState) error {
-	logger := logger.Log.WithFields(logrus.Fields{"account": rhcClient.Account, "client_id": rhcClient.ClientID})
+	logger := logger.Log.WithFields(logrus.Fields{"account": rhcClient.Account, "client_id": rhcClient.ClientID, "org_id": rhcClient.OrgID})
 
 	logger.Debug("FAKE: connected client recorder: ", rhcClient.CanonicalFacts)
 

--- a/internal/platform/logger/logger.go
+++ b/internal/platform/logger/logger.go
@@ -175,8 +175,9 @@ func LogError(msg string, err error) {
 	Log.WithFields(logrus.Fields{"error": err}).Error(msg)
 }
 
-func LogErrorWithAccountAndClientId(msg string, err error, account domain.AccountID, client_id domain.ClientID) {
+func LogErrorWithAccountAndClientId(msg string, err error, account domain.AccountID, org_id domain.OrgID, client_id domain.ClientID) {
 	Log.WithFields(logrus.Fields{"error": err,
 		"account":   account,
+		"org_id":    org_id,
 		"client_id": client_id}).Error(msg)
 }


### PR DESCRIPTION
## What?
Modify the logger calls to add the org_id label (just like the account label is currently added)
https://issues.redhat.com/browse/RHCLOUD-17729

## Why?
A step towards replacing EBS account_number with org_id

## How?
Added org_id in every log that contains the account ID

## Testing

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
