### PR TITLE
fix mismatch between API spec and implementation

### DIFF
--- a/internal/controller/api/api.spec.json
+++ b/internal/controller/api/api.spec.json
@@ -92,7 +92,7 @@
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "OK",
             "content": {
               "application/json": {


### PR DESCRIPTION
## What?
Fix mismatch between API spec and implementation.

## Why?
According to the spec the /connection_status operation returns 201 status code normally. However, the implementation in message_receiver.go sets the status code to 200. I assume the latter is the desired behavior.

## How?
Change the API spec to match the actual behavior.

## Testing
N/A

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
