### PR TITLE
Register the host with inventory if the 'package-manager' dispatcher is present

### DIFF
--- a/cmd/cloud-connector/inventory_stale_timestamp_updater.go
+++ b/cmd/cloud-connector/inventory_stale_timestamp_updater.go
@@ -50,7 +50,7 @@ func startInventoryStaleTimestampUpdater() {
 
 	kafkaProducer := queue.StartProducer(kafkaProducerCfg)
 
-	connectedClientRecorder, err := controller.NewInventoryBasedConnectedClientRecorder(kafkaProducer, cfg.InventoryStaleTimestampOffset, cfg.InventoryReporterName)
+	connectedClientRecorder, err := controller.NewInventoryBasedConnectedClientRecorder(controller.BuildInventoryMessageProducer(kafkaProducer), cfg.InventoryStaleTimestampOffset, cfg.InventoryReporterName)
 	if err != nil {
 		logger.LogFatalError("Failed to create Connected Client Recorder", err)
 	}

--- a/cmd/test_client/main.go
+++ b/cmd/test_client/main.go
@@ -175,6 +175,7 @@ func startProducer(certFile string, keyFile string, broker string, i int) {
 		dispatchers := make(Connector.Dispatchers)
 		dispatchers["rhc-worker-playbook"] = make(map[string]string)
 		dispatchers["rhc-worker-playbook"]["ansible-runner-version"] = "1.2.3"
+		dispatchers["package-manager"] = make(map[string]string)
 		dispatchers["echo"] = make(map[string]string)
 
 		dispatchers["catalog"] = make(map[string]string)

--- a/internal/cloud_connector/message_handlers_test.go
+++ b/internal/cloud_connector/message_handlers_test.go
@@ -45,6 +45,13 @@ func (mar *mockAccountIdResolver) MapClientIdToAccountId(ctx context.Context, cl
 	return domain.Identity("1111"), domain.AccountID("000111"), domain.OrgID("000001"), nil
 }
 
+type mockConnectedClientRecorder struct {
+}
+
+func (this *mockConnectedClientRecorder) RecordConnectedClient(ctx context.Context, identity domain.Identity, rhcClient domain.ConnectorClientState) error {
+	return nil
+}
+
 func TestHandleOnlineMessagesNoExistingConnection(t *testing.T) {
 
 	var mqttClient MQTT.Client
@@ -55,7 +62,7 @@ func TestHandleOnlineMessagesNoExistingConnection(t *testing.T) {
 	var connectionRegistrar = &mockConnectionRegistrar{
 		clients: make(map[domain.ClientID]domain.ConnectorClientState),
 	}
-	var connectedClientRecorder controller.ConnectedClientRecorder
+	var connectedClientRecorder = &mockConnectedClientRecorder{}
 	var sourcesRecorder controller.SourcesRecorder
 
 	incomingMessage := buildOnlineMessage(t, "56789", time.Now())
@@ -83,7 +90,7 @@ func TestHandleOnlineMessagesUpdateExistingConnection(t *testing.T) {
 	var connectionRegistrar = &mockConnectionRegistrar{
 		clients: make(map[domain.ClientID]domain.ConnectorClientState),
 	}
-	var connectedClientRecorder controller.ConnectedClientRecorder
+	var connectedClientRecorder = &mockConnectedClientRecorder{}
 	var sourcesRecorder controller.SourcesRecorder
 
 	var connectionState = domain.ConnectorClientState{
@@ -129,7 +136,7 @@ func TestHandleDuplicateAndOldOnlineMessages(t *testing.T) {
 	var cfg config.Config
 	var topicBuilder mqtt.TopicBuilder
 	var accountResolver = &mockAccountIdResolver{}
-	var connectedClientRecorder controller.ConnectedClientRecorder
+	var connectedClientRecorder = &mockConnectedClientRecorder{}
 	var sourcesRecorder controller.SourcesRecorder
 
 	now := time.Now()


### PR DESCRIPTION
## What?
Register the host with inventory if the `package-manager` dispatcher is present

## Why?
Config-Manager needs to be notified when a rhc connection is made which has the `package-manager` dispatcher.  Inventory will send out an event over kafka when a host is registered.  Config-Manager is watching for these events.

## How?
Modified the inventory based connected client recorder to send the `add_host` message to inventory if the connection has the 'package-manager' dispatcher.

## Testing
Added some automated tests to verify that the `add_host` message is sent to the kafka writer if the connection has the `package-manager` dispatcher.  These tests are still a work in progress that we can continue to improve as we go along, but its a start.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
