### PR TITLE
Modify the authentication middleware to retrieve the org_id from the top level of the header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/prometheus/client_golang v1.12.0
 	github.com/redhatinsights/app-common-go v1.6.0
-	github.com/redhatinsights/platform-go-middlewares v0.10.0
+	github.com/redhatinsights/platform-go-middlewares v0.12.0
 	github.com/segmentio/kafka-go v0.4.27
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -545,6 +545,8 @@ github.com/redhatinsights/app-common-go v1.6.0 h1:7ZW7dIVY3n9UImfoduG9wR7Tgiw3zy
 github.com/redhatinsights/app-common-go v1.6.0/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
 github.com/redhatinsights/platform-go-middlewares v0.10.0 h1:VVuWvPL7xHYnmVMz6jK9lUqyPc1vOEWdpo6eVu7e9iQ=
 github.com/redhatinsights/platform-go-middlewares v0.10.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
+github.com/redhatinsights/platform-go-middlewares v0.12.0 h1:gLFgsqupumRqAKDuYtvrYVNQr53iqfhQYc98VJ/cRUs=
+github.com/redhatinsights/platform-go-middlewares v0.12.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/internal/middlewares/auth.go
+++ b/internal/middlewares/auth.go
@@ -65,7 +65,7 @@ func GetPrincipal(ctx context.Context) (Principal, bool) {
 	p, ok := ctx.Value(principalKey).(serviceToServicePrincipal)
 	if !ok {
 		id, ok := ctx.Value(identity.Key).(identity.XRHID)
-		p := identityPrincipal{account: id.Identity.AccountNumber, orgID: id.Identity.Internal.OrgID}
+		p := identityPrincipal{account: id.Identity.AccountNumber, orgID: id.Identity.OrgID}
 		return p, ok
 	}
 	return p, ok


### PR DESCRIPTION
## What?
Modify the authentication middleware to retrieve the org_id from the top level of the header. [RHCLOUD-18144](https://issues.redhat.com/browse/RHCLOUD-18144)

## Why?
Part of the EBS to OrgID migration. Currently the authentication middleware is pulling the org_id from the "internal" section of the header. 

## How?
Updated the version of platform-middlewares and pulled OrgID from the top level.

## Testing
No changes needed to tests (Current tests already check for the OrgID, we are just grabbing it from a new location)

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
