### PR TITLE
RHCLOUD-18530: Send org-id to inventory

### DIFF
--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -127,6 +127,7 @@ func (ibccr *InventoryBasedConnectedClientRecorder) RecordConnectedClient(ctx co
 	hostData := cleanupCanonicalFacts(logger, originalHostData)
 
 	hostData["account"] = string(rhcClient.Account)
+	hostData["org_id"] = string(rhcClient.OrgID)
 	hostData["stale_timestamp"] = staleTimestamp.UTC().Format("2006-01-02T15:04:05Z07:00")
 	hostData["reporter"] = ibccr.ReporterName
 

--- a/internal/controller/connected_client_recorder_test.go
+++ b/internal/controller/connected_client_recorder_test.go
@@ -225,6 +225,15 @@ func validateInventoryMessage(b []byte, expectedClientID domain.ClientID) error 
 		return fmt.Errorf("could not parse inventory data field")
 	}
 
+	var orgID string
+	if orgID, ok = data["org_id"].(string); !ok {
+		return fmt.Errorf("could not parse \"org_id\" field")
+	}
+
+	if orgID != "9876" {
+		return fmt.Errorf("\"org_id\" (%s) field does not match expected data (%s)", orgID, expectedClientID)
+	}
+
 	if systemProfile, ok = data["system_profile"].(map[string]interface{}); !ok {
 		return fmt.Errorf("could not parse system_profile data")
 	}


### PR DESCRIPTION
## What?
Start sending the OrgID to inventory when hosts are created / updated.

## Why?
With the shift from EBS account-numbers to OrgID we should now be propagating the OrgID to all connected services alongside the Account number.

## How?
Added the "org_id" field to the host data being sent to the inventory topic.

## Testing
It looks like there are already tests in place that look for the OrgID.

## Anything Else?
JIRA:  https://issues.redhat.com/browse/RHCLOUD-18530

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
