### PR TITLE
Explicitly set the deployment strategy to recreate for the mqtt consumer

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -112,6 +112,10 @@ objects:
         metrics:
           enabled: False
       minReplicas: ${{MQTT_CONSUMER_REPLICAS}}
+      # Explicitly set the deployment strategy to recreate so that there is only
+      # one mqtt consumer running at a time
+      deploymentStrategy:
+        privateStrategy: Recreate
       podSpec:
         minReadySeconds: 15
         progressDeadlineSeconds: 600


### PR DESCRIPTION
## What?
Explicitly set the deployment strategy to recreate for the mqtt consumer

## Why?
There can only be one mqtt consumer running at a time.  This was the default configuration for a time, now its not.  So I'm explicitly setting it.
