### PR TITLE
Add org id populator job

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -302,6 +302,38 @@ objects:
 
 
     jobs:
+
+    - name: org-id-populator
+      podSpec:
+        image: quay.io/dehort/tenant-utils:f320347e8e4
+        command:
+          - ./org-id-column-populator
+          - -C
+          - -a
+          - account
+          - -o
+          - org_id
+          - -t
+          - connections
+          - --ean-translator-addr
+          - ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+        env:
+          - name: TENANT_TRANSLATOR_PROTOCOL
+            value: ${TENANT_TRANSLATOR_PROTOCOL}
+          - name: TENANT_TRANSLATOR_HOST
+            value: ${TENANT_TRANSLATOR_HOST}
+          - name: TENANT_TRANSLATOR_PORT
+            value: ${TENANT_TRANSLATOR_PORT}
+          - name: LOG_FORMAT
+            value: ${LOG_FORMAT}
+        resources:
+          limits:
+            cpu: 300m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 512Mi
+
     - name: connection-per-account-reporter
       schedule: ${CONNECTION_PER_ACCOUNT_REPORTER_SCHEDULE}
       suspend: ${{CONNECTION_PER_ACCOUNT_REPORTER_SUSPEND}}
@@ -573,3 +605,13 @@ parameters:
   value: "stdout"
 - name: CONNECTION_COUNT_PER_ACCOUNT_REPORT_ACCOUNT_EXCLUSION_LIST
   value: "477931,6089719,540155"
+
+- name: TENANT_TRANSLATOR_HOST
+  value: 'apicast.3scale-dev.svc.cluster.local'
+- name: TENANT_TRANSLATOR_PORT
+  value: '8892'
+- name: TENANT_TRANSLATOR_PROTOCOL
+  value: 'http'
+
+- name: PROMETHEUS_PUSH_GATEWAY
+  value: prometheus-push.insights-push-stage.svc.cluster.local:9091

--- a/deploy/run_org_id_populator.yaml
+++ b/deploy/run_org_id_populator.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdJobInvocation
+metadata:
+    name: populate-org-id-column-1
+spec:
+  appName: cloud-connector
+  jobs:
+    - org-id-populator


### PR DESCRIPTION
## What?
Add an openshift job that will run the org-id column population utility.

## Why?
Its possible that some of the rows in the connections table might not have an org-id.  The org-id needs to be populated moving forward.  Newly established connections will have the org-id already populated.  Its possible that "old" connections will not have the org-id column populated.

## How?
This PR adds an openshift job to run the org-id column population utility.  The utility will be pulled in as an image when the job is kicked off.

## Testing
Manual testing and verification using gabi

## Anything Else?


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
