### PR TITLE
Explicitly set the cloudwatch batch frequency on the org-id column population job

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -333,6 +333,8 @@ objects:
             value: ${LOG_FORMAT}
           - name: PROMETHEUS_PUSHGATEWAY
             value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: LOG_BATCH_FREQUENCY
+            value: '1'
         resources:
           limits:
             cpu: 300m

--- a/deploy/run_org_id_populator.yaml
+++ b/deploy/run_org_id_populator.yaml
@@ -2,7 +2,7 @@
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdJobInvocation
 metadata:
-    name: populate-org-id-column-11
+    name: populate-org-id-column-14
 spec:
   appName: cloud-connector
   jobs:


### PR DESCRIPTION
## What?
Explicitly set the cloudwatch batch frequency on the org-id column population job

## Why?
Make sure the logs are pushed to cloudwatch before the process exits.
