### PR TITLE
[WIP] Switch to confluent kafka library

### DIFF
--- a/cmd/cloud-connector/inventory_stale_timestamp_updater.go
+++ b/cmd/cloud-connector/inventory_stale_timestamp_updater.go
@@ -45,7 +45,7 @@ func startInventoryStaleTimestampUpdater() {
 
 	var kafkaProducerCfg *kafka.ConfigMap
 
-	if config.KAFKA_SASL_MECHANISM != "" {
+	if cfg.KafkaSASLMechanism != "" {
 		kafkaProducerCfg = &kafka.ConfigMap{
 			"bootstrap.servers":  strings.Join(cfg.InventoryKafkaBrokers, ","),
 			"security.protocol":  cfg.KafkaProtocol,

--- a/cmd/cloud-connector/inventory_stale_timestamp_updater.go
+++ b/cmd/cloud-connector/inventory_stale_timestamp_updater.go
@@ -47,22 +47,20 @@ func startInventoryStaleTimestampUpdater() {
 
 	if config.KAFKA_SASL_MECHANISM != "" {
 		kafkaProducerCfg = &kafka.ConfigMap{
-			"bootstrap.servers": strings.Join(cfg.InventoryKafkaBrokers, ","),
-			"security.protocol": cfg.KafkaProtocol,
-			"sasl.mechanism":    cfg.KafkaSASLMechanism,
-			"ssl.ca.location":   cfg.KafkaCA,
-			"sasl.username":     cfg.KafkaUsername,
-			"sasl.password":     cfg.KafkaPassword,
-			"batch.num.message": cfg.InventoryKafkaBatchSize,
-			"batch.size":        cfg.InventoryKafkaBatchSize,
-			"balance.strategy":  "hash",
+			"bootstrap.servers":  strings.Join(cfg.InventoryKafkaBrokers, ","),
+			"security.protocol":  cfg.KafkaProtocol,
+			"sasl.mechanism":     cfg.KafkaSASLMechanism,
+			"ssl.ca.location":    cfg.KafkaCA,
+			"sasl.username":      cfg.KafkaUsername,
+			"sasl.password":      cfg.KafkaPassword,
+			"batch.num.messages": cfg.InventoryKafkaBatchSize,
+			"batch.size":         cfg.InventoryKafkaBatchSize,
 		}
 	} else {
 		kafkaProducerCfg = &kafka.ConfigMap{
-			"bootstrap.servers": strings.Join(cfg.InventoryKafkaBrokers, ","),
-			"batch.num.message": cfg.InventoryKafkaBatchSize,
-			"batch.size":        cfg.InventoryKafkaBatchSize,
-			"balance.strategy":  "hash",
+			"bootstrap.servers":  strings.Join(cfg.InventoryKafkaBrokers, ","),
+			"batch.num.messages": cfg.InventoryKafkaBatchSize,
+			"batch.size":         cfg.InventoryKafkaBatchSize,
 		}
 	}
 

--- a/cmd/cloud-connector/inventory_stale_timestamp_updater.go
+++ b/cmd/cloud-connector/inventory_stale_timestamp_updater.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/RedHatInsights/cloud-connector/internal/config"
@@ -46,7 +47,7 @@ func startInventoryStaleTimestampUpdater() {
 
 	if config.KAFKA_SASL_MECHANISM != "" {
 		kafkaProducerCfg = &kafka.ConfigMap{
-			"bootstrap.servers": cfg.InventoryKafkaBrokers,
+			"bootstrap.servers": strings.Join(cfg.InventoryKafkaBrokers, ","),
 			"security.protocol": cfg.KafkaProtocol,
 			"sasl.mechanism":    cfg.KafkaSASLMechanism,
 			"ssl.ca.location":   cfg.KafkaCA,
@@ -58,7 +59,7 @@ func startInventoryStaleTimestampUpdater() {
 		}
 	} else {
 		kafkaProducerCfg = &kafka.ConfigMap{
-			"bootstrap.servers": cfg.InventoryKafkaBrokers,
+			"bootstrap.servers": strings.Join(cfg.InventoryKafkaBrokers, ","),
 			"batch.num.message": cfg.InventoryKafkaBatchSize,
 			"batch.size":        cfg.InventoryKafkaBatchSize,
 			"balance.strategy":  "hash",

--- a/cmd/cloud-connector/kafka_message_consumer.go
+++ b/cmd/cloud-connector/kafka_message_consumer.go
@@ -239,8 +239,6 @@ func consumeMqttMessagesFromKafka(kafkaReader *kafka.Consumer,
 			case <-ctx.Done():
 				return
 			default:
-				logger.Log.Debugf("message from topic partition %d at offset %d: %s = %s", msg.TopicPartition.Partition, msg.TopicPartition.Offset, string(msg.Key), string(msg.Value))
-				metrics.kafkaMessageReceivedCounter.Inc()
 		}
 
 		if err != nil {
@@ -249,9 +247,10 @@ func consumeMqttMessagesFromKafka(kafkaReader *kafka.Consumer,
 				fatalProcessingError <- struct{}{}
 			}
 
-			continue
-			
+			continue	
 		}
+		logger.Log.Debugf("message from topic partition %d at offset %d: %s = %s", msg.TopicPartition.Partition, msg.TopicPartition.Offset, string(msg.Key), string(msg.Value))
+		metrics.kafkaMessageReceivedCounter.Inc()
 		
 		process(msg)
 	}

--- a/cmd/cloud-connector/kafka_message_consumer.go
+++ b/cmd/cloud-connector/kafka_message_consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -78,7 +79,7 @@ func startKafkaMessageConsumer(mgmtAddr string) {
 	mqttTopicVerifier := mqtt.NewTopicVerifier(cfg.MqttTopicPrefix)
 
 	rhcMessageKafkaConsumer = kafka.ConfigMap{
-		"bootstrap.servers": cfg.RhcMessageKafkaBrokers,
+		"bootstrap.servers": strings.Join(cfg.RhcMessageKafkaBrokers, ","),
 		"group.id":          cfg.RhcMessageKafkaConsumerGroup,
 	}
 

--- a/cmd/cloud-connector/mqtt_message_consumer.go
+++ b/cmd/cloud-connector/mqtt_message_consumer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/RedHatInsights/cloud-connector/internal/config"
@@ -55,7 +56,7 @@ func startMqttMessageConsumer(mgmtAddr string) {
 	mqttTopicVerifier := mqtt.NewTopicVerifier(cfg.MqttTopicPrefix)
 
 	kafkaProducerCfg := &kafka.ConfigMap{
-		"bootstrap.servers":  cfg.RhcMessageKafkaBrokers,
+		"bootstrap.servers":  strings.Join(cfg.RhcMessageKafkaBrokers, ","),
 		"batch.num.messages": cfg.RhcMessageKafkaBatchSize,
 		"batch.size":         cfg.RhcMessageKafkaBatchBytes,
 		"balance.strategy":   "hash",

--- a/cmd/cloud-connector/mqtt_message_consumer.go
+++ b/cmd/cloud-connector/mqtt_message_consumer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/RedHatInsights/cloud-connector/internal/platform/queue"
 	"github.com/RedHatInsights/cloud-connector/internal/platform/utils"
 	"github.com/RedHatInsights/cloud-connector/internal/platform/utils/tls_utils"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 
 	"github.com/gorilla/mux"
 )
@@ -53,12 +54,11 @@ func startMqttMessageConsumer(mgmtAddr string) {
 	mqttTopicBuilder := mqtt.NewTopicBuilder(cfg.MqttTopicPrefix)
 	mqttTopicVerifier := mqtt.NewTopicVerifier(cfg.MqttTopicPrefix)
 
-	kafkaProducerCfg := &queue.ProducerConfig{
-		Brokers:    cfg.RhcMessageKafkaBrokers,
-		Topic:      cfg.RhcMessageKafkaTopic,
-		BatchSize:  cfg.RhcMessageKafkaBatchSize,
-		BatchBytes: cfg.RhcMessageKafkaBatchBytes,
-		Balancer:   "hash",
+	kafkaProducerCfg := &kafka.ConfigMap{
+		"bootstrap.servers":  cfg.RhcMessageKafkaBrokers,
+		"batch.num.messages": cfg.RhcMessageKafkaBatchSize,
+		"batch.size":         cfg.RhcMessageKafkaBatchBytes,
+		"balance.strategy":   "hash",
 	}
 
 	kafkaProducer := queue.StartProducer(kafkaProducerCfg)

--- a/cmd/cloud-connector/mqtt_message_consumer.go
+++ b/cmd/cloud-connector/mqtt_message_consumer.go
@@ -59,7 +59,6 @@ func startMqttMessageConsumer(mgmtAddr string) {
 		"bootstrap.servers":  strings.Join(cfg.RhcMessageKafkaBrokers, ","),
 		"batch.num.messages": cfg.RhcMessageKafkaBatchSize,
 		"batch.size":         cfg.RhcMessageKafkaBatchBytes,
-		"balance.strategy":   "hash",
 	}
 
 	kafkaProducer := queue.StartProducer(kafkaProducerCfg)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.42.44
+	github.com/confluentinc/confluent-kafka-go v1.8.2 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/felixge/httpsnoop v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20190925194419-606b3d062051/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
+github.com/confluentinc/confluent-kafka-go v1.8.2 h1:PBdbvYpyOdFLehj8j+9ba7FL4c4Moxn79gy9cYKxG5E=
+github.com/confluentinc/confluent-kafka-go v1.8.2/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/containerd/containerd v1.4.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.1 h1:pASeJT3R3YyVn+94qEPk0SnU1OQ20Jd/T+SPKy9xehY=
 github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,11 @@ const (
 	AUTH_GATEWAY_URL                             = "Auth_Gateway_Url"
 	AUTH_GATEWAY_HTTP_CLIENT_TIMEOUT             = "Auth_Gateway_HTTP_Client_Timeout"
 	DEFAULT_KAFKA_BROKER_ADDRESS                 = "kafka:29092"
+	KAFKA_CA							 	     = "Kafka_CA"
+	KAFKA_USERNAME					 			 = "Kafka_Username"
+	KAFKA_PASSWORD					 			 = "Kafka_Password"
+	KAFKA_SASL_MECHANISM				 		 = "Kafka_SASL_Mechanism"
+	KAFKA_PROTOCOL					 			 = "Kafka_Protocol"
 	CONNECTED_CLIENT_RECORDER_IMPL               = "Connected_Client_Recorder_Impl"
 	INVENTORY_KAFKA_BROKERS                      = "Inventory_Kafka_Brokers"
 	INVENTORY_KAFKA_TOPIC                        = "Inventory_Kafka_Topic"
@@ -108,6 +113,11 @@ type Config struct {
 	MqttDisconnectQuiesceTime               uint
 	InvalidHandshakeReconnectDelay          int
 	KafkaBrokers                            []string
+	KafkaCA									string
+	KafkaUsername							string
+	KafkaPassword							string
+	KafkaSASLMechanism						string
+	KafkaProtocol							string
 	ClientIdToAccountIdImpl                 string
 	ClientIdToAccountIdConfigFile           string
 	ClientIdToAccountIdDefaultAccountId     string
@@ -189,6 +199,11 @@ func (c Config) String() string {
 	fmt.Fprintf(&b, "%s: %s\n", CONNECTION_DATABASE_SQLITE_FILE, c.ConnectionDatabaseSqliteFile)
 	fmt.Fprintf(&b, "%s: %s\n", CONNECTION_DATABASE_QUERY_TIMEOUT, c.ConnectionDatabaseQueryTimeout)
 	fmt.Fprintf(&b, "%s: %s\n", CONNECTED_CLIENT_RECORDER_IMPL, c.ConnectedClientRecorderImpl)
+	fmt.Fprintf(&b, "%s: %s\n", KAFKA_CA, c.KafkaCA)
+	fmt.Fprintf(&b, "%s: %s\n", KAFKA_USERNAME, c.KafkaUsername)
+	fmt.Fprintf(&b, "%s: %s\n", KAFKA_PASSWORD, c.KafkaPassword)
+	fmt.Fprintf(&b, "%s: %s\n", KAFKA_SASL_MECHANISM, c.KafkaSASLMechanism)
+	fmt.Fprintf(&b, "%s: %s\n", KAFKA_PROTOCOL, c.KafkaProtocol)
 	fmt.Fprintf(&b, "%s: %s\n", INVENTORY_KAFKA_BROKERS, c.InventoryKafkaBrokers)
 	fmt.Fprintf(&b, "%s: %s\n", INVENTORY_KAFKA_TOPIC, c.InventoryKafkaTopic)
 	fmt.Fprintf(&b, "%s: %d\n", INVENTORY_KAFKA_BATCH_SIZE, c.InventoryKafkaBatchSize)
@@ -321,6 +336,11 @@ func GetConfig() *Config {
 		AuthGatewayUrl:                          options.GetString(AUTH_GATEWAY_URL),
 		AuthGatewayHttpClientTimeout:            options.GetDuration(AUTH_GATEWAY_HTTP_CLIENT_TIMEOUT) * time.Second,
 		ConnectedClientRecorderImpl:             options.GetString(CONNECTED_CLIENT_RECORDER_IMPL),
+		KafkaCA:						 		 options.GetString(KAFKA_CA),
+		KafkaUsername:					 		 options.GetString(KAFKA_USERNAME),
+		KafkaPassword:					 		 options.GetString(KAFKA_PASSWORD),
+		KafkaSASLMechanism:			 			 options.GetString(KAFKA_SASL_MECHANISM),
+		KafkaProtocol:				     		 options.GetString(KAFKA_PROTOCOL),
 		InventoryKafkaBrokers:                   options.GetStringSlice(INVENTORY_KAFKA_BROKERS),
 		InventoryKafkaTopic:                     options.GetString(INVENTORY_KAFKA_TOPIC),
 		InventoryKafkaBatchSize:                 options.GetInt(INVENTORY_KAFKA_BATCH_SIZE),
@@ -347,6 +367,7 @@ func GetConfig() *Config {
 
 	if clowder.IsClowderEnabled() {
 		cfg := clowder.LoadedConfig
+		broker := cfg.Kafka.Brokers[0]
 
 		fmt.Println("Cloud-Connector is running in a Clowderized environment...overriding configuration!!")
 
@@ -360,6 +381,19 @@ func GetConfig() *Config {
 			fmt.Println("WARNING:  RHC Message kafka topic is not set within clowder!!")
 			// FIXME:  this is a hack!!
 			config.RhcMessageKafkaTopic = RHC_MESSAGE_KAFKA_TOPIC_DEFAULT
+		}
+
+		if broker.Authtype != nil {
+			caPath, err := cfg.KafkaCa(broker)
+			if err != nil {
+				panic("Kafka CA cert failed to write")
+			}
+
+			config.KafkaUsername      = *broker.Sasl.Username 
+			config.KafkaPassword      = *broker.Sasl.Password
+			config.KafkaSASLMechanism = "SCRAM_SHA_512"
+			config.KafkaProtocol      = "sasl_ssl"
+			config.KafkaCA            = caPath
 		}
 
 		config.ConnectionDatabaseHost = cfg.Database.Hostname

--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -45,14 +45,12 @@ func NewConnectedClientRecorder(impl string, cfg *config.Config) (ConnectedClien
 				"sasl.password":     cfg.KafkaPassword,
 				"batch.num.message": cfg.InventoryKafkaBatchSize,
 				"batch.size":        cfg.InventoryKafkaBatchSize,
-				"balance.strategy":  "hash",
 			}
 		} else {
 			kafkaProducerCfg = &kafka.ConfigMap{
 				"bootstrap.servers": strings.Join(cfg.InventoryKafkaBrokers, ","),
 				"batch.num.message": cfg.InventoryKafkaBatchSize,
 				"batch.size":        cfg.InventoryKafkaBatchSize,
-				"balance.strategy":  "hash",
 			}
 		}
 

--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/RedHatInsights/cloud-connector/internal/config"
@@ -36,7 +37,7 @@ func NewConnectedClientRecorder(impl string, cfg *config.Config) (ConnectedClien
 	case "inventory":
 		if config.KAFKA_SASL_MECHANISM != "" {
 			kafkaProducerCfg = &kafka.ConfigMap{
-				"bootstrap.servers": cfg.InventoryKafkaBrokers,
+				"bootstrap.servers": strings.Join(cfg.InventoryKafkaBrokers, ","),
 				"security.protocol": cfg.KafkaProtocol,
 				"sasl.mechanism":    cfg.KafkaSASLMechanism,
 				"ssl.ca.location":   cfg.KafkaCA,
@@ -48,7 +49,7 @@ func NewConnectedClientRecorder(impl string, cfg *config.Config) (ConnectedClien
 			}
 		} else {
 			kafkaProducerCfg = &kafka.ConfigMap{
-				"bootstrap.servers": cfg.InventoryKafkaBrokers,
+				"bootstrap.servers": strings.Join(cfg.InventoryKafkaBrokers, ","),
 				"batch.num.message": cfg.InventoryKafkaBatchSize,
 				"batch.size":        cfg.InventoryKafkaBatchSize,
 				"balance.strategy":  "hash",

--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -35,7 +35,7 @@ func NewConnectedClientRecorder(impl string, cfg *config.Config) (ConnectedClien
 
 	switch impl {
 	case "inventory":
-		if config.KAFKA_SASL_MECHANISM != "" {
+		if cfg.KafkaSASLMechanism != "" {
 			kafkaProducerCfg = &kafka.ConfigMap{
 				"bootstrap.servers":  strings.Join(cfg.InventoryKafkaBrokers, ","),
 				"security.protocol":  cfg.KafkaProtocol,

--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -37,20 +37,20 @@ func NewConnectedClientRecorder(impl string, cfg *config.Config) (ConnectedClien
 	case "inventory":
 		if config.KAFKA_SASL_MECHANISM != "" {
 			kafkaProducerCfg = &kafka.ConfigMap{
-				"bootstrap.servers": strings.Join(cfg.InventoryKafkaBrokers, ","),
-				"security.protocol": cfg.KafkaProtocol,
-				"sasl.mechanism":    cfg.KafkaSASLMechanism,
-				"ssl.ca.location":   cfg.KafkaCA,
-				"sasl.username":     cfg.KafkaUsername,
-				"sasl.password":     cfg.KafkaPassword,
-				"batch.num.message": cfg.InventoryKafkaBatchSize,
-				"batch.size":        cfg.InventoryKafkaBatchSize,
+				"bootstrap.servers":  strings.Join(cfg.InventoryKafkaBrokers, ","),
+				"security.protocol":  cfg.KafkaProtocol,
+				"sasl.mechanism":     cfg.KafkaSASLMechanism,
+				"ssl.ca.location":    cfg.KafkaCA,
+				"sasl.username":      cfg.KafkaUsername,
+				"sasl.password":      cfg.KafkaPassword,
+				"batch.num.messages": cfg.InventoryKafkaBatchSize,
+				"batch.size":         cfg.InventoryKafkaBatchSize,
 			}
 		} else {
 			kafkaProducerCfg = &kafka.ConfigMap{
-				"bootstrap.servers": strings.Join(cfg.InventoryKafkaBrokers, ","),
-				"batch.num.message": cfg.InventoryKafkaBatchSize,
-				"batch.size":        cfg.InventoryKafkaBatchSize,
+				"bootstrap.servers":  strings.Join(cfg.InventoryKafkaBrokers, ","),
+				"batch.num.messages": cfg.InventoryKafkaBatchSize,
+				"batch.size":         cfg.InventoryKafkaBatchSize,
 			}
 		}
 

--- a/internal/platform/queue/consumer.go
+++ b/internal/platform/queue/consumer.go
@@ -2,7 +2,7 @@ package queue
 
 import (
 	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
-	kafka "github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 func StartConsumer(cfg *kafka.ConfigMap, topic string) (*kafka.Consumer, error) {

--- a/internal/platform/queue/consumer.go
+++ b/internal/platform/queue/consumer.go
@@ -2,21 +2,26 @@ package queue
 
 import (
 	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
-	kafka "github.com/segmentio/kafka-go"
+	kafka "github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
-func StartConsumer(cfg *ConsumerConfig) *kafka.Reader {
-	logger.Log.Info("Starting a new kafka consumer...")
-	logger.Log.Info("Kafka consumer configuration: ", cfg)
+func StartConsumer(cfg *kafka.ConfigMap, topic string) (*kafka.Consumer, error) {
+	logger.Log.Info("Starting Kafka Message consumer...")
+	logger.Log.Info("Kafka consumer configureation: ", cfg)
 
-	r := kafka.NewReader(kafka.ReaderConfig{
-		Brokers:     cfg.Brokers,
-		Topic:       cfg.Topic,
-		GroupID:     cfg.GroupID,
-		StartOffset: cfg.ConsumerOffset,
-	})
+	consumer, err := kafka.NewConsumer(cfg)
 
-	logger.Log.Info("Kafka consumer config: ", r.Config())
+	if err != nil {
+		return nil, err
+	}
 
-	return r
+	err = consumer.SubscribeTopics([]string{topic}, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Log.Info("Connected to Kafka")
+
+	return consumer, nil
 }

--- a/internal/platform/queue/producer.go
+++ b/internal/platform/queue/producer.go
@@ -2,27 +2,17 @@ package queue
 
 import (
 	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
-	kafka "github.com/segmentio/kafka-go"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
-func StartProducer(cfg *ProducerConfig) *kafka.Writer {
-	logger.Log.Info("Starting a new Kafka producer..")
-	logger.Log.Info("Kafka producer configuration: ", cfg)
+func StartProducer(cfg *kafka.ConfigMap) *kafka.Producer {
+	logger.Log.Info("Starting Kafka Message producer...")
+	logger.Log.Info("Kafka producer configureation: ", cfg)
 
-	writerConfig := kafka.WriterConfig{
-		Brokers:    cfg.Brokers,
-		Topic:      cfg.Topic,
-		BatchSize:  cfg.BatchSize,
-		BatchBytes: cfg.BatchBytes,
+	producer, err := kafka.NewProducer(cfg)
+	if err != nil {
+		logger.LogFatalError("Failed to create Kafka producer", err)
 	}
 
-	if cfg.Balancer == "hash" {
-		writerConfig.Balancer = &kafka.Hash{}
-	}
-
-	w := kafka.NewWriter(writerConfig)
-
-	logger.Log.Info("Producing messages to topic: ", cfg.Topic)
-
-	return w
+	return producer
 }


### PR DESCRIPTION
Switch over to confluent kafka library in order to support
authentication

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Switch to confluent kafka and support authentication

## Why?
Switching over to confluent kafka library gives us what we need to support authentication to kafka servers.

## How?
Switched the consumer and producer logic to be in line with confluent kafka. Had to add a few things related to the ssl stuff for kafka in fedramp and managed kafka. 

## Testing
The tests for this one are all using mocked consumers and producers. Need to test this in ephemeral to really try it out against a kafka service.

## Anything Else?
This is a pretty big PR, but the changes to the producers are largely the same. Ended up just having a global kafka auth config since we're pulling it from clowder and we only do auth on the platform side. If we add some kind of auth to MQTT later, then we might need to do some stuff there. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
