### PR TITLE
Implement the v2 rest interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,3 +345,42 @@ Two complete examples of data messages as published by the *Client*:
     "content": "rejected"
 }
 ```
+
+## Internal REST interface
+
+The internal REST interface can be used to retreive the list of connections which belong to an organization,
+get information about a connection and send messages to a connected client.
+This REST interface is only available within the cluster where cloud-connector is deployed.
+
+In order to authenticate, the client is required to pass either the identity header or the following
+pre-shared key headers:
+
+```
+"x-rh-cloud-connector-org-id"
+"x-rh-cloud-connector-client-id"
+"x-rh-cloud-connector-psk"
+```
+
+If your service is internal and will not be passing requests through 3scale a psk will be provided.
+This psk will be unique to your service.
+The `x-rh-cloud-connector-org-id` is required so that cloud-connector knows which organzation it is
+acting on behalf of.
+
+### Get list of connections for an organization
+
+```
+GET /v2/connections
+```
+
+### Get status of a connection
+
+```
+GET /v2/connections/{client_id}/status
+```
+
+### Send a message to a connected client
+```
+POST /v2/connections/{client_id}/message
+```
+
+See [API schema](./internal/controller/api/api.spec.json) for more details.

--- a/cmd/cloud-connector/api_server.go
+++ b/cmd/cloud-connector/api_server.go
@@ -179,6 +179,19 @@ func startCloudConnectorApiServer(mgmtAddr string) {
 	jr := api.NewMessageReceiver(permittedTenantConnectionLocator, apiMux, cfg.UrlBasePath, cfg)
 	jr.Routes()
 
+	getConnectionFunction, err := connection_repository.NewSqlGetConnectionByClientID(cfg, database)
+	if err != nil {
+		logger.LogFatalError("Unable to create connection_repository.GetConnection() function", err)
+	}
+
+	getConnectionListByOrgIDFunction, err := connection_repository.NewSqlGetConnectionsByOrgID(cfg, database)
+	if err != nil {
+		logger.LogFatalError("Unable to create connection_repository.GetConnectionsByOrgID() function", err)
+	}
+
+	connectionMediator := api.NewConnectionMediatorV2(getConnectionFunction, getConnectionListByOrgIDFunction, proxyFactory, apiMux, cfg.UrlBasePath, cfg)
+	connectionMediator.Routes()
+
 	apiSrv := utils.StartHTTPServer(mgmtAddr, "management", apiMux)
 
 	signalChan := make(chan os.Signal, 1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -416,5 +416,5 @@ func GetConfig() *Config {
 }
 
 func buildUrlBasePath(pathPrefix string, appName string) string {
-	return fmt.Sprintf("/%s/%s/v1", pathPrefix, appName)
+	return fmt.Sprintf("/%s/%s", pathPrefix, appName)
 }

--- a/internal/connection_repository/sql_connection_locator_v2.go
+++ b/internal/connection_repository/sql_connection_locator_v2.go
@@ -1,0 +1,170 @@
+package connection_repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/RedHatInsights/cloud-connector/internal/config"
+	"github.com/RedHatInsights/cloud-connector/internal/domain"
+	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+func NewSqlGetConnectionByClientID(cfg *config.Config, database *sql.DB) (GetConnectionByClientID, error) {
+
+	return func(ctx context.Context, log *logrus.Entry, orgId domain.OrgID, clientId domain.ClientID) (domain.ConnectorClientState, error) {
+		var clientState domain.ConnectorClientState
+		var err error
+
+		callDurationTimer := prometheus.NewTimer(metrics.sqlLookupConnectionByAccountAndClientIDDuration)
+		defer callDurationTimer.ObserveDuration()
+
+		ctx, cancel := context.WithTimeout(ctx, cfg.ConnectionDatabaseQueryTimeout)
+		defer cancel()
+
+		statement, err := database.Prepare(`SELECT  account, dispatchers, canonical_facts, tags
+            FROM connections WHERE org_id = $1 AND client_id = $2`)
+		if err != nil {
+			logger.LogWithError(log, "SQL Prepare failed", err)
+			return clientState, nil
+		}
+		defer statement.Close()
+
+		var accountString sql.NullString
+		var dispatchersString sql.NullString
+		var canonicalFactsString sql.NullString
+		var tagsString sql.NullString
+
+		err = statement.QueryRowContext(ctx, orgId, clientId).Scan(&accountString, &dispatchersString, &canonicalFactsString, &tagsString)
+
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return clientState, NotFoundError
+			}
+
+			logger.LogWithError(log, "SQL query failed:", err)
+			return clientState, err
+		}
+
+		clientState.OrgID = orgId
+		clientState.ClientID = clientId
+
+		if accountString.Valid {
+			clientState.Account = domain.AccountID(accountString.String)
+		}
+
+		if dispatchersString.Valid {
+			err = json.Unmarshal([]byte(dispatchersString.String), &clientState.Dispatchers)
+			if err != nil {
+				logger.LogErrorWithAccountAndClientId("Unable to parse dispatchers from database.", err, clientState.Account, clientState.OrgID, clientState.ClientID)
+			}
+		}
+
+		if canonicalFactsString.Valid {
+			err = json.Unmarshal([]byte(canonicalFactsString.String), &clientState.CanonicalFacts)
+			if err != nil {
+				logger.LogErrorWithAccountAndClientId("Unable to parse canonical facts from database.", err, clientState.Account, clientState.OrgID, clientState.ClientID)
+			}
+		}
+
+		if tagsString.Valid {
+			err = json.Unmarshal([]byte(tagsString.String), &clientState.Tags)
+			if err != nil {
+				logger.LogErrorWithAccountAndClientId("Unable to parse tags from database.", err, clientState.Account, clientState.OrgID, clientState.ClientID)
+			}
+		}
+
+		return clientState, nil
+	}, nil
+}
+
+func NewSqlGetConnectionsByOrgID(cfg *config.Config, database *sql.DB) (GetConnectionsByOrgID, error) {
+
+	return func(ctx context.Context, log *logrus.Entry, orgId domain.OrgID, offset int, limit int) (map[domain.ClientID]domain.ConnectorClientState, int, error) {
+
+		var totalConnections int
+
+		callDurationTimer := prometheus.NewTimer(metrics.sqlLookupConnectionsByAccountDuration)
+		defer callDurationTimer.ObserveDuration()
+
+		ctx, cancel := context.WithTimeout(ctx, cfg.ConnectionDatabaseQueryTimeout)
+		defer cancel()
+
+		connectionsPerAccount := make(map[domain.ClientID]domain.ConnectorClientState)
+
+		fmt.Println("orgId: ", orgId)
+		fmt.Println("limit: ", limit)
+		fmt.Println("offset: ", offset)
+
+		statement, err := database.Prepare(
+			`SELECT client_id, org_id, account, dispatchers, canonical_facts, tags, COUNT(*) OVER() FROM connections
+                WHERE org_id = $1
+                ORDER BY client_id
+                OFFSET $2
+                LIMIT $3`)
+		if err != nil {
+			logger.LogWithError(log, "SQL Prepare failed", err)
+			return nil, totalConnections, err
+		}
+		defer statement.Close()
+
+		rows, err := statement.QueryContext(ctx, orgId, offset, limit)
+		if err != nil {
+			logger.LogWithError(log, "SQL query failed", err)
+			return nil, totalConnections, err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var clientId domain.ClientID
+			var orgId string
+			var accountString sql.NullString
+			var dispatchersString sql.NullString
+			var canonicalFactsString sql.NullString
+			var tagsString sql.NullString
+
+			if err := rows.Scan(&clientId, &orgId, &accountString, &dispatchersString, &canonicalFactsString, &tagsString, &totalConnections); err != nil {
+				logger.LogWithError(log, "SQL scan failed.  Skipping row.", err)
+				continue
+			}
+
+			clientState := domain.ConnectorClientState{
+				OrgID:    domain.OrgID(orgId),
+				ClientID: clientId,
+			}
+
+			if accountString.Valid {
+				clientState.Account = domain.AccountID(accountString.String)
+			}
+
+			if dispatchersString.Valid {
+				err = json.Unmarshal([]byte(dispatchersString.String), &clientState.Dispatchers)
+				if err != nil {
+					logger.LogErrorWithAccountAndClientId("Unable to parse dispatchers from database.", err, clientState.Account, clientState.OrgID, clientState.ClientID)
+				}
+			}
+
+			if canonicalFactsString.Valid {
+				err = json.Unmarshal([]byte(canonicalFactsString.String), &clientState.CanonicalFacts)
+				if err != nil {
+					logger.LogErrorWithAccountAndClientId("Unable to parse canonical facts from database.", err, clientState.Account, clientState.OrgID, clientState.ClientID)
+				}
+			}
+
+			if tagsString.Valid {
+				err = json.Unmarshal([]byte(tagsString.String), &clientState.Tags)
+				if err != nil {
+					logger.LogErrorWithAccountAndClientId("Unable to parse tags from database.", err, clientState.Account, clientState.OrgID, clientState.ClientID)
+				}
+			}
+
+			connectionsPerAccount[clientId] = clientState
+		}
+
+		return connectionsPerAccount, totalConnections, nil
+	}, nil
+}

--- a/internal/connection_repository/types.go
+++ b/internal/connection_repository/types.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/RedHatInsights/cloud-connector/internal/controller"
 	"github.com/RedHatInsights/cloud-connector/internal/domain"
+
+	"github.com/sirupsen/logrus"
 )
 
 type FatalError struct {
@@ -27,3 +29,6 @@ type ConnectionLocator interface {
 	GetConnectionsByAccount(context.Context, domain.AccountID, int, int) (map[domain.ClientID]controller.ConnectorClient, int, error)
 	GetAllConnections(context.Context, int, int) (map[domain.AccountID]map[domain.ClientID]controller.ConnectorClient, int, error)
 }
+
+type GetConnectionByClientID func(context.Context, *logrus.Entry, domain.OrgID, domain.ClientID) (domain.ConnectorClientState, error)
+type GetConnectionsByOrgID func(context.Context, *logrus.Entry, domain.OrgID, int, int) (map[domain.ClientID]domain.ConnectorClientState, int, error)

--- a/internal/controller/api/connection_mediator_v2.go
+++ b/internal/controller/api/connection_mediator_v2.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/RedHatInsights/cloud-connector/internal/config"
+	"github.com/RedHatInsights/cloud-connector/internal/connection_repository"
+	"github.com/RedHatInsights/cloud-connector/internal/controller"
+	"github.com/RedHatInsights/cloud-connector/internal/domain"
+	"github.com/RedHatInsights/cloud-connector/internal/middlewares"
+	logging "github.com/RedHatInsights/cloud-connector/internal/platform/logger"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/redhatinsights/platform-go-middlewares/request_id"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+type ConnectionMediatorV2 struct {
+	getConnectionByClientID connection_repository.GetConnectionByClientID
+	getConnectionsByOrgID   connection_repository.GetConnectionsByOrgID
+	router                  *mux.Router
+	config                  *config.Config
+	urlPrefix               string
+	proxyFactory            controller.ConnectorClientProxyFactory
+}
+
+func NewConnectionMediatorV2(byClientID connection_repository.GetConnectionByClientID, byOrgID connection_repository.GetConnectionsByOrgID, proxyFactory controller.ConnectorClientProxyFactory, r *mux.Router, urlPrefix string, cfg *config.Config) *ConnectionMediatorV2 {
+	return &ConnectionMediatorV2{
+		getConnectionByClientID: byClientID,
+		getConnectionsByOrgID:   byOrgID,
+		router:                  r,
+		config:                  cfg,
+		urlPrefix:               urlPrefix,
+		proxyFactory:            proxyFactory,
+	}
+}
+
+func (this *ConnectionMediatorV2) Routes() {
+	mmw := &middlewares.MetricsMiddleware{}
+	amw := &middlewares.AuthMiddleware{
+		Secrets:                  this.config.ServiceToServiceCredentials,
+		IdentityAuth:             identity.EnforceIdentity,
+		RequiredTenantIdentifier: middlewares.OrgID, // OrgID is the required tenant identifier for v2 rest interface
+	}
+
+	securedSubRouter := this.router.PathPrefix(this.urlPrefix).Subrouter()
+	securedSubRouter.Use(logging.AccessLoggerMiddleware,
+		mmw.RecordHTTPMetrics,
+		amw.Authenticate)
+
+	securedSubRouter.HandleFunc("/v2/connections/{id}/message", this.handleSendMessage()).Methods(http.MethodPost)
+	securedSubRouter.HandleFunc("/v2/connections/{id}/status", this.handleConnectionStatus()).Methods(http.MethodGet)
+	securedSubRouter.HandleFunc("/v2/connections", this.handleConnectionListByOrgId()).Methods(http.MethodGet)
+}
+
+type messageRequestV2 struct {
+	Payload   interface{} `json:"payload" validate:"required"`
+	Metadata  interface{} `json:"metadata"`
+	Directive string      `json:"directive" validate:"required"`
+}
+
+func (this *ConnectionMediatorV2) handleSendMessage() http.HandlerFunc {
+
+	return func(w http.ResponseWriter, req *http.Request) {
+
+		principal, _ := middlewares.GetPrincipal(req.Context())
+		requestId := request_id.GetReqID(req.Context())
+
+		recipient := getClientIDFromRequestPath(req)
+
+		logger := logging.Log.WithFields(logrus.Fields{
+			"account":    principal.GetAccount(),
+			"org_id":     principal.GetOrgID(),
+			"request_id": requestId,
+			"recipient":  recipient,
+		})
+
+		var msgRequest messageRequestV2
+
+		body := http.MaxBytesReader(w, req.Body, 1048576)
+
+		if err := decodeJSON(body, &msgRequest); err != nil {
+			errMsg := "Unable to process json input"
+			logging.LogWithError(logger, errMsg, err)
+			errorResponse := errorResponse{Title: errMsg,
+				Status: http.StatusBadRequest,
+				Detail: err.Error()}
+			writeJSONResponse(w, errorResponse.Status, errorResponse)
+			return
+		}
+
+		if len(strings.TrimSpace(msgRequest.Directive)) == 0 {
+			logger.Debug(emptyDirectictiveErrorMsg)
+			errorResponse := errorResponse{Title: emptyDirectictiveErrorMsg,
+				Status: http.StatusBadRequest,
+				Detail: emptyDirectictiveErrorMsg}
+			writeJSONResponse(w, errorResponse.Status, errorResponse)
+			return
+		}
+
+		var clientState domain.ConnectorClientState
+		var err error
+		clientState, err = this.getConnectionByClientID(req.Context(), logger, domain.OrgID(principal.GetOrgID()), recipient)
+		if err != nil {
+
+			if err == connection_repository.NotFoundError {
+				writeConnectionFailureResponse(logger, w)
+				return
+			}
+
+			logging.LogWithError(logger, "Unable to locate connection", err)
+
+			writeConnectionFailureResponse(logger, w)
+			return
+		}
+
+		client, err := this.proxyFactory.CreateProxy(req.Context(), clientState.Account, clientState.ClientID, clientState.Dispatchers)
+		if err != nil {
+			logging.LogWithError(logger, "Unable to create proxy for connection", err)
+			writeConnectionFailureResponse(logger, w)
+			return
+		}
+
+		logger = logger.WithFields(logrus.Fields{"directive": msgRequest.Directive})
+		logger.Info("Sending a message")
+
+		jobID, err := client.SendMessage(req.Context(),
+			msgRequest.Directive,
+			msgRequest.Metadata,
+			msgRequest.Payload)
+
+		if err == controller.ErrDisconnectedNode {
+			writeConnectionFailureResponse(logger, w)
+			return
+		}
+
+		if err != nil {
+			logging.LogWithError(logger, "Error passing message to rhc client", err)
+			errorResponse := errorResponse{Title: "Error passing message to rhc client",
+				Status: http.StatusInternalServerError,
+				Detail: err.Error()}
+			writeJSONResponse(w, errorResponse.Status, errorResponse)
+			return
+		}
+
+		logger.WithFields(logrus.Fields{"message_id": jobID}).Info("Message sent")
+
+		msgResponse := messageResponse{jobID.String()}
+
+		writeJSONResponse(w, http.StatusCreated, msgResponse)
+	}
+}
+
+func getClientIDFromRequestPath(req *http.Request) domain.ClientID {
+	params := mux.Vars(req)
+	return domain.ClientID(params["id"])
+}
+
+type connectionResponseV2 struct {
+	Account        domain.AccountID      `json:"account,omitempty"`
+	OrgID          domain.OrgID          `json:"org_id,omitempty"`
+	ClientID       domain.ClientID       `json:"client_id,omitempty"`
+	CanonicalFacts domain.CanonicalFacts `json:"canonical_facts,omitempty"`
+	Dispatchers    domain.Dispatchers    `json:"dispatchers,omitempty"`
+	Tags           domain.Tags           `json:"tags,omitempty"`
+}
+
+type connectionStatusResponseV2 struct {
+	Status string `json:"status"`
+	connectionResponseV2
+}
+
+func (this *ConnectionMediatorV2) handleConnectionStatus() http.HandlerFunc {
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		principal, _ := middlewares.GetPrincipal(req.Context())
+		requestId := request_id.GetReqID(req.Context())
+
+		recipient := getClientIDFromRequestPath(req)
+
+		logger := logging.Log.WithFields(logrus.Fields{
+			"account":    principal.GetAccount(),
+			"org_id":     principal.GetOrgID(),
+			"request_id": requestId,
+			"recipient":  recipient,
+		})
+
+		var clientState domain.ConnectorClientState
+		var err error
+
+		clientState, err = this.getConnectionByClientID(req.Context(), logger, domain.OrgID(principal.GetOrgID()), recipient)
+		if err != nil {
+			if err == connection_repository.NotFoundError {
+				logger.Debug("Connection not found")
+				response := connectionStatusResponseV2{Status: DISCONNECTED_STATUS}
+				writeJSONResponse(w, http.StatusOK, response)
+				return
+			}
+
+			logging.LogWithError(logger, "Failed to lookup connection", err)
+
+			writeConnectionFailureResponse(logger, w)
+			return
+		}
+
+		logger.Debug("Connection found")
+
+		response := convertConnectorClientStateToConnectionStatusResponseV2(clientState)
+		writeJSONResponse(w, http.StatusOK, response)
+		return
+	}
+}
+
+func convertConnectorClientStateToConnectionStatusResponseV2(clientState domain.ConnectorClientState) connectionStatusResponseV2 {
+	return connectionStatusResponseV2{"connected", convertConnectorClientStateToConnectionResponseV2(clientState)}
+}
+
+func convertConnectorClientStateToConnectionResponseV2(clientState domain.ConnectorClientState) connectionResponseV2 {
+	return connectionResponseV2{
+		Account:        clientState.Account,
+		OrgID:          clientState.OrgID,
+		ClientID:       clientState.ClientID,
+		CanonicalFacts: clientState.CanonicalFacts,
+		Dispatchers:    clientState.Dispatchers,
+		Tags:           clientState.Tags,
+	}
+}
+
+func (this *ConnectionMediatorV2) handleConnectionListByOrgId() http.HandlerFunc {
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		principal, _ := middlewares.GetPrincipal(req.Context())
+		requestId := request_id.GetReqID(req.Context())
+
+		logger := logging.Log.WithFields(logrus.Fields{
+			"account":    principal.GetAccount(),
+			"org_id":     principal.GetOrgID(),
+			"request_id": requestId})
+
+		logger.Debug("Getting connections for ", principal.GetOrgID())
+
+		offset, limit, err := getOffsetAndLimitFromQueryParams(req)
+		if err != nil {
+			logging.LogWithError(logger, "Unable to retrieve offset/limit from request", err)
+			errorResponse := errorResponse{Title: "Invalid request",
+				Status: http.StatusBadRequest,
+				Detail: err.Error()}
+			writeJSONResponse(w, errorResponse.Status, errorResponse)
+			return
+		}
+
+		accountConnections, totalConnections, err := this.getConnectionsByOrgID(
+			req.Context(),
+			logger,
+			domain.OrgID(principal.GetOrgID()),
+			offset,
+			limit)
+
+		if err != nil {
+			logging.LogWithError(logger, "Error looking up connections by org_id", err)
+			errorResponse := errorResponse{Title: "Error looking up connections by org_id",
+				Status: http.StatusInternalServerError,
+				Detail: err.Error()}
+			writeJSONResponse(w, errorResponse.Status, errorResponse)
+		}
+
+		connections := make([]connectionResponseV2, len(accountConnections))
+
+		connCount := 0
+		for _, conn := range accountConnections {
+			connections[connCount] = convertConnectorClientStateToConnectionResponseV2(conn)
+			connCount++
+		}
+
+		response := buildPaginatedResponse(req.URL, offset, limit, totalConnections, connections)
+
+		writeJSONResponse(w, http.StatusOK, response)
+	}
+}

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -53,7 +53,7 @@ func (s *ManagementServer) Routes() {
 		RequiredTenantIdentifier: middlewares.Account, // Account is the required tenant identifier for v1 rest interface
 	}
 
-	pathPrefix := fmt.Sprintf("%s/connection", s.urlPrefix)
+	pathPrefix := fmt.Sprintf("%s/v1/connection", s.urlPrefix)
 
 	securedSubRouter := s.router.PathPrefix(pathPrefix).Subrouter()
 	securedSubRouter.Use(logger.AccessLoggerMiddleware,

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 const (
-	CONNECTION_LIST_ENDPOINT       = URL_BASE_PATH + "/connection"
-	CONNECTION_STATUS_ENDPOINT     = URL_BASE_PATH + "/connection/status"
-	CONNECTION_RECONNECT_ENDPOINT  = URL_BASE_PATH + "/connection/reconnect"
-	CONNECTION_DISCONNECT_ENDPOINT = URL_BASE_PATH + "/connection/disconnect"
-	CONNECTION_PING_ENDPOINT       = URL_BASE_PATH + "/connection/ping"
+	CONNECTION_LIST_ENDPOINT       = URL_BASE_PATH + "/v1/connection"
+	CONNECTION_STATUS_ENDPOINT     = URL_BASE_PATH + "/v1/connection/status"
+	CONNECTION_RECONNECT_ENDPOINT  = URL_BASE_PATH + "/v1/connection/reconnect"
+	CONNECTION_DISCONNECT_ENDPOINT = URL_BASE_PATH + "/v1/connection/disconnect"
+	CONNECTION_PING_ENDPOINT       = URL_BASE_PATH + "/v1/connection/ping"
 
 	CONNECTED_ACCOUNT_NUMBER = "1234"
 	CONNECTED_NODE_ID        = "345"
@@ -337,8 +337,8 @@ var _ = Describe("Management", func() {
 				var expectedResponse = paginatedResponse{
 					Meta: meta{Count: 1},
 					Links: navigationLinks{
-						First: "/api/cloud-connector/api/v1/connection?limit=1000&offset=0",
-						Last:  "/api/cloud-connector/api/v1/connection?limit=1000&offset=0",
+						First: "/api/cloud-connector/v1/connection?limit=1000&offset=0",
+						Last:  "/api/cloud-connector/v1/connection?limit=1000&offset=0",
 						Next:  "",
 						Prev:  "",
 					},
@@ -427,8 +427,8 @@ var _ = Describe("Management", func() {
 				var expectedResponse = paginatedResponse{
 					Meta: meta{Count: 1},
 					Links: navigationLinks{
-						First: "/api/cloud-connector/api/v1/connection/1234?limit=1000&offset=0",
-						Last:  "/api/cloud-connector/api/v1/connection/1234?limit=1000&offset=0",
+						First: "/api/cloud-connector/v1/connection/1234?limit=1000&offset=0",
+						Last:  "/api/cloud-connector/v1/connection/1234?limit=1000&offset=0",
 						Next:  "",
 						Prev:  "",
 					},

--- a/internal/controller/api/message_receiver.go
+++ b/internal/controller/api/message_receiver.go
@@ -52,8 +52,8 @@ func (jr *MessageReceiver) Routes() {
 		mmw.RecordHTTPMetrics,
 		amw.Authenticate)
 
-	securedSubRouter.HandleFunc("/message", jr.handleJob()).Methods(http.MethodPost)
-	securedSubRouter.HandleFunc("/connection_status", jr.handleConnectionStatus()).Methods(http.MethodPost)
+	securedSubRouter.HandleFunc("/v1/message", jr.handleJob()).Methods(http.MethodPost)
+	securedSubRouter.HandleFunc("/v1/connection_status", jr.handleConnectionStatus()).Methods(http.MethodPost)
 }
 
 type messageRequest struct {

--- a/internal/controller/api/message_receiver_test.go
+++ b/internal/controller/api/message_receiver_test.go
@@ -28,8 +28,8 @@ const (
 	TOKEN_HEADER_CLIENT_NAME  = middlewares.PSKClientIdHeader
 	TOKEN_HEADER_ACCOUNT_NAME = middlewares.PSKAccountHeader
 	TOKEN_HEADER_PSK_NAME     = middlewares.PSKHeader
-	URL_BASE_PATH             = "/api/cloud-connector/api/v1"
-	MESSAGE_ENDPOINT          = URL_BASE_PATH + "/message"
+	URL_BASE_PATH             = "/api/cloud-connector"
+	MESSAGE_ENDPOINT          = URL_BASE_PATH + "/v1/message"
 )
 
 type MockClientProxyFactory struct {
@@ -462,7 +462,7 @@ var _ = Describe("MessageReceiver", func() {
 
 				postBody := createConnectionStatusPostBody(CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID)
 
-				req, err := http.NewRequest("POST", URL_BASE_PATH+"/connection_status", postBody)
+				req, err := http.NewRequest("POST", URL_BASE_PATH+"/v1/connection_status", postBody)
 				Expect(err).NotTo(HaveOccurred())
 
 				validIdentityHeader = buildIdentityHeader("4321", "Associate") // Use the "wrong" account number here
@@ -486,7 +486,7 @@ var _ = Describe("MessageReceiver", func() {
 
 				postBody := createConnectionStatusPostBody(CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID)
 
-				req, err := http.NewRequest("POST", URL_BASE_PATH+"/connection_status", postBody)
+				req, err := http.NewRequest("POST", URL_BASE_PATH+"/v1/connection_status", postBody)
 				Expect(err).NotTo(HaveOccurred())
 
 				req.Header.Add(TOKEN_HEADER_CLIENT_NAME, "test_client_1")

--- a/internal/controller/api/utils.go
+++ b/internal/controller/api/utils.go
@@ -95,3 +95,17 @@ func getOffsetFromQueryParams(req *http.Request) (int, error) {
 
 	return offset, nil
 }
+
+func getOffsetAndLimitFromQueryParams(req *http.Request) (offset int, limit int, err error) {
+	limit, err = getLimitFromQueryParams(req)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	offset, err = getOffsetFromQueryParams(req)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return offset, limit, nil
+}

--- a/internal/platform/logger/logger.go
+++ b/internal/platform/logger/logger.go
@@ -175,6 +175,10 @@ func LogError(msg string, err error) {
 	Log.WithFields(logrus.Fields{"error": err}).Error(msg)
 }
 
+func LogWithError(log *logrus.Entry, msg string, err error) {
+	log.WithFields(logrus.Fields{"error": err}).Error(msg)
+}
+
 func LogErrorWithAccountAndClientId(msg string, err error, account domain.AccountID, org_id domain.OrgID, client_id domain.ClientID) {
 	Log.WithFields(logrus.Fields{"error": err,
 		"account":   account,


### PR DESCRIPTION
## What?
Implement the v2 rest interface for the internal "customer" facing operations.

The v2 rest interface does not require explicitly passing the account number / org id as part of the request body.  The v2 endpoints do require org-id header (x-rh-cloud-connector-org-id) when using psk based authentication.

The internal "customer" facing v2 calls are: 
POST /v2/connections/{client_id}/message
GET /v2/connections/{client_id}/status
GET /v2/connections (return the list of connections that belong to an org)

## Why?
Account number is no longer the primary tenant id within the platform.

## How?
- v2 connection lookup is separate from the http interface
- v2 connection lookup does not use the proxy factory anymore
- v2 connection lookup just returns the state of the connection
- proxy factory can take connection state and create a proxy (which has knowledge of mqtt) for sending messages
- v2 http layer doesn't know about databases or mqtt
- v2 http layer is passed a proxy factory which can build a proxy capable of sending mqtt requests

## Testing
Only manual testing at the moment :disappointed: 

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
