### PR TITLE
Make the required tenant id header configurable for psk based authentication

### DIFF
--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -42,13 +42,15 @@ func NewManagementServer(cm connection_repository.ConnectionLocator, r *mux.Rout
 
 func (s *ManagementServer) Routes() {
 	mmw := &middlewares.MetricsMiddleware{}
-	amw := &middlewares.AuthMiddleware{Secrets: s.config.ServiceToServiceCredentials,
+	amw := &middlewares.AuthMiddleware{
+		Secrets: s.config.ServiceToServiceCredentials,
 		IdentityAuth: func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				identity.EnforceIdentity(middlewares.EnforceTurnpikeAuthentication(next)).ServeHTTP(w, r)
 				return
 			})
 		},
+		RequiredTenantIdentifier: middlewares.Account, // Account is the required tenant identifier for v1 rest interface
 	}
 
 	pathPrefix := fmt.Sprintf("%s/connection", s.urlPrefix)

--- a/internal/controller/api/message_receiver.go
+++ b/internal/controller/api/message_receiver.go
@@ -41,7 +41,11 @@ func NewMessageReceiver(cm connection_repository.ConnectionLocator, r *mux.Route
 
 func (jr *MessageReceiver) Routes() {
 	mmw := &middlewares.MetricsMiddleware{}
-	amw := &middlewares.AuthMiddleware{Secrets: jr.config.ServiceToServiceCredentials, IdentityAuth: identity.EnforceIdentity}
+	amw := &middlewares.AuthMiddleware{
+		Secrets:                  jr.config.ServiceToServiceCredentials,
+		IdentityAuth:             identity.EnforceIdentity,
+		RequiredTenantIdentifier: middlewares.Account, // Account is the required tenant identifier for v1 rest interface
+	}
 
 	securedSubRouter := jr.router.PathPrefix(jr.urlPrefix).Subrouter()
 	securedSubRouter.Use(logger.AccessLoggerMiddleware,

--- a/internal/middlewares/princiapl.go
+++ b/internal/middlewares/princiapl.go
@@ -1,0 +1,53 @@
+package middlewares
+
+import (
+	"context"
+
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+// Principal interface can be implemented and expanded by various principal objects (type depends on middleware being used)
+type Principal interface {
+	GetAccount() string
+	GetOrgID() string
+}
+
+type key int
+
+var principalKey key
+
+type serviceToServicePrincipal struct {
+	account, clientID, orgID string
+}
+
+func (sp serviceToServicePrincipal) GetAccount() string {
+	return sp.account
+}
+
+func (sp serviceToServicePrincipal) GetOrgID() string {
+	return sp.orgID
+}
+
+type identityPrincipal struct {
+	account, orgID string
+}
+
+func (ip identityPrincipal) GetAccount() string {
+	return ip.account
+}
+
+func (ip identityPrincipal) GetOrgID() string {
+	return ip.orgID
+}
+
+// GetPrincipal takes the request context and determines which middleware (identity header vs service to service) was used
+// before returning a principal object.
+func GetPrincipal(ctx context.Context) (Principal, bool) {
+	p, ok := ctx.Value(principalKey).(serviceToServicePrincipal)
+	if !ok {
+		id, ok := ctx.Value(identity.Key).(identity.XRHID)
+		p := identityPrincipal{account: id.Identity.AccountNumber, orgID: id.Identity.OrgID}
+		return p, ok
+	}
+	return p, ok
+}

--- a/internal/middlewares/service_credentials.go
+++ b/internal/middlewares/service_credentials.go
@@ -1,0 +1,35 @@
+package middlewares
+
+import (
+	"errors"
+)
+
+type serviceCredentials struct {
+	clientID string
+	orgID    string
+	account  string
+	psk      string
+}
+
+func newServiceCredentials(clientID, orgID, account, psk string) *serviceCredentials {
+	return &serviceCredentials{
+		clientID: clientID,
+		orgID:    orgID,
+		account:  account,
+		psk:      psk,
+	}
+}
+
+type serviceCredentialsValidator struct {
+	knownServiceCredentials map[string]interface{}
+}
+
+func (scv *serviceCredentialsValidator) validate(sc *serviceCredentials) error {
+	switch {
+	case scv.knownServiceCredentials[sc.clientID] == nil:
+		return errors.New(authErrorLogHeader + "Provided ClientID not attached to any known keys")
+	case sc.psk != scv.knownServiceCredentials[sc.clientID]:
+		return errors.New(authErrorLogHeader + "Provided PSK does not match known key for this client")
+	}
+	return nil
+}


### PR DESCRIPTION
## What?
Make the required tenant id header configurable for psk based authentication

## Why?
This is required for the v2 rest interface.  The v1 rest interface needs to still require the account number, but the v2 rest interface needs to allow the account number and require the org id.

## How?
Added a new flag on the authentication middleware.

## Testing
Unit tests were added to cover this.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
