### PR TITLE
Add a migration to remove the permitted_tenants column [RHCLOUD-20479]

### DIFF
--- a/db/migrations/000008_drop-permitted-tenenants-column.down.sql
+++ b/db/migrations/000008_drop-permitted-tenenants-column.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE connections
+    ADD permitted_tenants jsonb DEFAULT '[]';
+
+CREATE INDEX idx_permitted_tenants_gin ON connections USING gin (permitted_tenants);

--- a/db/migrations/000008_drop-permitted-tenenants-column.up.sql
+++ b/db/migrations/000008_drop-permitted-tenenants-column.up.sql
@@ -1,0 +1,4 @@
+DROP INDEX idx_permitted_tenants_gin;
+
+ALTER TABLE connections
+    DROP COLUMN permitted_tenants;

--- a/internal/connection_repository/sql_connection_registrar.go
+++ b/internal/connection_repository/sql_connection_registrar.go
@@ -42,10 +42,8 @@ func (scm *SqlConnectionRegistrar) Register(ctx context.Context, rhcClient domai
 
 	logger := logger.Log.WithFields(logrus.Fields{"account": account, "org_id": org_id, "client_id": client_id})
 
-	permittedTenants := "[]"
-
-	update := "UPDATE connections SET dispatchers=$1, tags = $2, updated_at = NOW(), message_id = $3, message_sent = $4, permitted_tenants = $5 WHERE account=$6 AND client_id=$7"
-	insert := "INSERT INTO connections (account, org_id, client_id, dispatchers, canonical_facts, tags, permitted_tenants, message_id, message_sent) SELECT $8, $9, $10, $11, $12, $13, $14, $15, $16"
+	update := "UPDATE connections SET dispatchers=$1, tags = $2, updated_at = NOW(), message_id = $3, message_sent = $4 WHERE account=$5 AND client_id=$6"
+	insert := "INSERT INTO connections (account, org_id, client_id, dispatchers, canonical_facts, tags, message_id, message_sent) SELECT $7, $8, $9, $10, $11, $12, $13, $14"
 
 	insertOrUpdate := fmt.Sprintf("WITH upsert AS (%s RETURNING *) %s WHERE NOT EXISTS (SELECT * FROM upsert)", update, insert)
 
@@ -74,7 +72,7 @@ func (scm *SqlConnectionRegistrar) Register(ctx context.Context, rhcClient domai
 		return err
 	}
 
-	_, err = statement.ExecContext(ctx, dispatchersString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp, permittedTenants, account, client_id, account, org_id, client_id, dispatchersString, canonicalFactsString, tagsString, permittedTenants, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp)
+	_, err = statement.ExecContext(ctx, dispatchersString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp, account, client_id, account, org_id, client_id, dispatchersString, canonicalFactsString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp)
 	if err != nil {
 		logger.WithFields(logrus.Fields{"error": err}).Error("Insert/update failed")
 		return FatalError{err}

--- a/internal/connection_repository/sql_connection_registrar_test.go
+++ b/internal/connection_repository/sql_connection_registrar_test.go
@@ -72,8 +72,6 @@ func TestSqlConnectionRegistrar(t *testing.T) {
 
 			verifyConnectorClientState(t, connectorClientState, actualClientState)
 
-			verifyStoredClientState(t, database, tc.account, tc.clientID, []string{})
-
 			err = connectionRegistrar.Unregister(context.TODO(), tc.clientID)
 			if err != nil {
 				t.Fatal("unexpected error while registering a connection", err)
@@ -93,33 +91,4 @@ func verifyConnectorClientState(t *testing.T, expectedClientState, actualClientS
 		expectedClientState.ClientID != actualClientState.ClientID {
 		t.Fatal("actual client state does not match expected client state", actualClientState, expectedClientState)
 	}
-}
-
-func verifyStoredClientState(t *testing.T, database *sql.DB, account domain.AccountID, clientID domain.ClientID, permittedTenants []string) {
-
-	statement, err := database.Prepare(`SELECT permitted_tenants FROM connections
-    WHERE account = $1 AND
-    client_id = $2`)
-	if err != nil {
-		t.Fatal("sql prepare failed", err)
-		return
-	}
-	defer statement.Close()
-
-	var permittedTenantsFromDatabase string
-	err = statement.QueryRow(account, clientID).Scan(&permittedTenantsFromDatabase)
-	if err != nil {
-		t.Fatal("sql prepare failed", err)
-		return
-	}
-
-	var actualPermittedTenents []string
-	json.Unmarshal([]byte(permittedTenantsFromDatabase), &actualPermittedTenents)
-
-	if reflect.DeepEqual(actualPermittedTenents, permittedTenants) == false {
-		t.Fatalf("expected permitted tenants to be %s, but got %s", permittedTenants, actualPermittedTenents)
-		return
-	}
-
-	return
 }

--- a/internal/connection_repository/sql_connection_registrar_test.go
+++ b/internal/connection_repository/sql_connection_registrar_test.go
@@ -5,9 +5,7 @@ package connection_repository
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/RedHatInsights/cloud-connector/internal/config"


### PR DESCRIPTION
## What?
Create a db migration that removes the `permitted_tenants` column from the `connections` table
https://issues.redhat.com/browse/RHCLOUD-20479

## Why?
The `permitted_tenants` column is no longer being used

## How?
Adds an additional migration to remove the index and drop the field
Also updated the `sql_connection_registrar` to stop using the `permitted_tenants` field

## Testing
Updated `sql_connection_registrar_test` to stop looking for `permitted_tenants`
Migration checked in ephemeral:
![image](https://user-images.githubusercontent.com/39098327/185429977-c3abd110-e717-453b-9fe8-275a478fa87e.png)
![image](https://user-images.githubusercontent.com/39098327/185430147-4eda82b6-d757-4cab-9123-319595d0ff60.png)


## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
