### PR TITLE
Making payload field optional for the v1 and v2 message endpoint [RHCLOUD-20916]

### DIFF
--- a/internal/controller/api/connection_mediator_v2.go
+++ b/internal/controller/api/connection_mediator_v2.go
@@ -56,7 +56,7 @@ func (this *ConnectionMediatorV2) Routes() {
 }
 
 type messageRequestV2 struct {
-	Payload   interface{} `json:"payload" validate:"required"`
+	Payload   interface{} `json:"payload"`
 	Metadata  interface{} `json:"metadata"`
 	Directive string      `json:"directive" validate:"required"`
 }

--- a/internal/controller/api/connection_mediator_v2_test.go
+++ b/internal/controller/api/connection_mediator_v2_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/RedHatInsights/cloud-connector/internal/config"
+	"github.com/RedHatInsights/cloud-connector/internal/domain"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	MESSAGE_ENDPOINT_V2 = URL_BASE_PATH + "/v2/connections/345/message"
+	ACCOUNT_NUMBER      = domain.AccountID("1234")
+)
+
+func MockedGetConnectionByClientID(context.Context, *logrus.Entry, domain.OrgID, domain.ClientID) (domain.ConnectorClientState, error) {
+	return domain.ConnectorClientState{Account: ACCOUNT_NUMBER, ClientID: "345"}, nil
+}
+
+func MockedGetConnectionsByOrgID(context.Context, *logrus.Entry, domain.OrgID, int, int) (map[domain.ClientID]domain.ConnectorClientState, int, error) {
+	return map[domain.ClientID]domain.ConnectorClientState{"345": {Account: ACCOUNT_NUMBER, ClientID: "345"}}, 1, nil
+}
+
+var _ = Describe("ConnectionMediatorV2", func() {
+
+	var (
+		cm                  *ConnectionMediatorV2
+		validIdentityHeader string
+	)
+
+	BeforeEach(func() {
+		apiMux := mux.NewRouter()
+		cfg := config.GetConfig()
+
+		proxyFactory := &MockClientProxyFactory{}
+
+		cm = NewConnectionMediatorV2(MockedGetConnectionByClientID, MockedGetConnectionsByOrgID, proxyFactory, apiMux, URL_BASE_PATH, cfg)
+		cm.Routes()
+
+		validIdentityHeader = buildIdentityHeader(ACCOUNT_NUMBER, "Associate")
+	})
+
+	Describe("Connecting to the v2 message endpoint", func() {
+		Context("With valid identity header", func() {
+			It("Should be able to send a job to a client", func() {
+				postBody := "{\"payload\": [\"678\"], \"directive\": \"fred:flintstone\"}"
+
+				req, err := http.NewRequest("POST", MESSAGE_ENDPOINT_V2, strings.NewReader(postBody))
+				Expect(err).NotTo(HaveOccurred())
+
+				req.Header.Add(IDENTITY_HEADER_NAME, validIdentityHeader)
+
+				rr := httptest.NewRecorder()
+
+				cm.router.ServeHTTP(rr, req)
+
+				Expect(rr.Code).To(Equal(http.StatusCreated))
+
+				var m map[string]string
+				json.Unmarshal(rr.Body.Bytes(), &m)
+				Expect(m).Should(HaveKey("id"))
+			})
+
+			It("Should be able to send a job to a client without the payload field", func() {
+				postBody := "{\"directive\": \"fred:flintstone\"}"
+
+				req, err := http.NewRequest("POST", MESSAGE_ENDPOINT_V2, strings.NewReader(postBody))
+				Expect(err).NotTo(HaveOccurred())
+
+				req.Header.Add(IDENTITY_HEADER_NAME, validIdentityHeader)
+
+				rr := httptest.NewRecorder()
+
+				cm.router.ServeHTTP(rr, req)
+
+				Expect(rr.Code).To(Equal(http.StatusCreated))
+
+				var m map[string]string
+				json.Unmarshal(rr.Body.Bytes(), &m)
+				Expect(m).Should(HaveKey("id"))
+			})
+		})
+	})
+})

--- a/internal/controller/api/connection_mediator_v2_test.go
+++ b/internal/controller/api/connection_mediator_v2_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/RedHatInsights/cloud-connector/internal/config"
+	"github.com/RedHatInsights/cloud-connector/internal/connection_repository"
 	"github.com/RedHatInsights/cloud-connector/internal/domain"
 
 	"github.com/gorilla/mux"
@@ -22,18 +24,36 @@ const (
 	ACCOUNT_NUMBER      = domain.AccountID("1234")
 )
 
-func MockedGetConnectionByClientID(context.Context, *logrus.Entry, domain.OrgID, domain.ClientID) (domain.ConnectorClientState, error) {
-	return domain.ConnectorClientState{Account: ACCOUNT_NUMBER, ClientID: "345"}, nil
+func mockedGetConnectionByClientID(expectedOrgId domain.OrgID, expectedAccount domain.AccountID, expectedClientId domain.ClientID) connection_repository.GetConnectionByClientID {
+	return func(ctx context.Context, log *logrus.Entry, actualOrgId domain.OrgID, actualClientId domain.ClientID) (domain.ConnectorClientState, error) {
+		if actualOrgId != expectedOrgId {
+			return domain.ConnectorClientState{}, fmt.Errorf("Actual org id does not match expected org id")
+		}
+
+		if actualClientId != expectedClientId {
+			return domain.ConnectorClientState{}, fmt.Errorf("Actual client id does not match expected client id")
+		}
+
+		return domain.ConnectorClientState{OrgID: actualOrgId, Account: expectedAccount, ClientID: actualClientId}, nil
+	}
 }
 
-func MockedGetConnectionsByOrgID(context.Context, *logrus.Entry, domain.OrgID, int, int) (map[domain.ClientID]domain.ConnectorClientState, int, error) {
-	return map[domain.ClientID]domain.ConnectorClientState{"345": {Account: ACCOUNT_NUMBER, ClientID: "345"}}, 1, nil
+func mockedGetConnectionsByOrgID(expectedOrgId domain.OrgID, expectedAccount domain.AccountID, expectedClientId domain.ClientID) connection_repository.GetConnectionsByOrgID {
+	return func(ctx context.Context, log *logrus.Entry, actualOrgId domain.OrgID, offset int, limit int) (map[domain.ClientID]domain.ConnectorClientState, int, error) {
+		if actualOrgId != expectedOrgId {
+			return map[domain.ClientID]domain.ConnectorClientState{}, 0, fmt.Errorf("Actual org id does not match expected org id")
+		}
+
+		return map[domain.ClientID]domain.ConnectorClientState{expectedClientId: {Account: expectedAccount, ClientID: expectedClientId}}, 1, nil
+	}
 }
 
 var _ = Describe("ConnectionMediatorV2", func() {
 
 	var (
 		cm                  *ConnectionMediatorV2
+		messageEndpointV2   string
+		accountNumber       domain.AccountID
 		validIdentityHeader string
 	)
 
@@ -43,10 +63,19 @@ var _ = Describe("ConnectionMediatorV2", func() {
 
 		proxyFactory := &MockClientProxyFactory{}
 
-		cm = NewConnectionMediatorV2(MockedGetConnectionByClientID, MockedGetConnectionsByOrgID, proxyFactory, apiMux, URL_BASE_PATH, cfg)
+		messageEndpointV2 = URL_BASE_PATH + "/v2/connections/345/message"
+		accountNumber = "1234"
+		validIdentityHeader = buildIdentityHeader(accountNumber, "Associate")
+
+		orgID := domain.OrgID("1979710")
+		clientID := domain.ClientID("345")
+
+		getConnByClientID := mockedGetConnectionByClientID(orgID, accountNumber, clientID)
+		getConnByOrgID := mockedGetConnectionsByOrgID(orgID, accountNumber, clientID)
+
+		cm = NewConnectionMediatorV2(getConnByClientID, getConnByOrgID, proxyFactory, apiMux, URL_BASE_PATH, cfg)
 		cm.Routes()
 
-		validIdentityHeader = buildIdentityHeader(ACCOUNT_NUMBER, "Associate")
 	})
 
 	Describe("Connecting to the v2 message endpoint", func() {
@@ -54,7 +83,7 @@ var _ = Describe("ConnectionMediatorV2", func() {
 			It("Should be able to send a job to a client", func() {
 				postBody := "{\"payload\": [\"678\"], \"directive\": \"fred:flintstone\"}"
 
-				req, err := http.NewRequest("POST", MESSAGE_ENDPOINT_V2, strings.NewReader(postBody))
+				req, err := http.NewRequest("POST", messageEndpointV2, strings.NewReader(postBody))
 				Expect(err).NotTo(HaveOccurred())
 
 				req.Header.Add(IDENTITY_HEADER_NAME, validIdentityHeader)
@@ -73,7 +102,7 @@ var _ = Describe("ConnectionMediatorV2", func() {
 			It("Should be able to send a job to a client without the payload field", func() {
 				postBody := "{\"directive\": \"fred:flintstone\"}"
 
-				req, err := http.NewRequest("POST", MESSAGE_ENDPOINT_V2, strings.NewReader(postBody))
+				req, err := http.NewRequest("POST", messageEndpointV2, strings.NewReader(postBody))
 				Expect(err).NotTo(HaveOccurred())
 
 				req.Header.Add(IDENTITY_HEADER_NAME, validIdentityHeader)

--- a/internal/controller/api/connection_mediator_v2_test.go
+++ b/internal/controller/api/connection_mediator_v2_test.go
@@ -88,6 +88,21 @@ var _ = Describe("ConnectionMediatorV2", func() {
 				json.Unmarshal(rr.Body.Bytes(), &m)
 				Expect(m).Should(HaveKey("id"))
 			})
+
+			It("Should not be able to send a job to a client with empty post body", func() {
+				postBody := "{}"
+
+				req, err := http.NewRequest("POST", MESSAGE_ENDPOINT_V2, strings.NewReader(postBody))
+				Expect(err).NotTo(HaveOccurred())
+
+				req.Header.Add(IDENTITY_HEADER_NAME, validIdentityHeader)
+
+				rr := httptest.NewRecorder()
+
+				cm.router.ServeHTTP(rr, req)
+
+				Expect(rr.Code).To(Equal(http.StatusBadRequest))
+			})
 		})
 	})
 })

--- a/internal/controller/api/message_receiver.go
+++ b/internal/controller/api/message_receiver.go
@@ -59,7 +59,7 @@ func (jr *MessageReceiver) Routes() {
 type messageRequest struct {
 	Account   string      `json:"account" validate:"required"`
 	Recipient string      `json:"recipient" validate:"required"`
-	Payload   interface{} `json:"payload" validate:"required"`
+	Payload   interface{} `json:"payload"`
 	Metadata  interface{} `json:"metadata"`
 	Directive string      `json:"directive" validate:"required"`
 }

--- a/internal/controller/api/message_receiver_test.go
+++ b/internal/controller/api/message_receiver_test.go
@@ -35,7 +35,7 @@ const (
 type MockClientProxyFactory struct {
 }
 
-func (MockClientProxyFactory) CreateProxy(context.Context, domain.AccountID, domain.ClientID, domain.Dispatchers) (controller.ConnectorClient, error) {
+func (MockClientProxyFactory) CreateProxy(context.Context, domain.OrgID, domain.AccountID, domain.ClientID, domain.Dispatchers) (controller.ConnectorClient, error) {
 	return MockClient{}, nil
 }
 
@@ -344,6 +344,21 @@ var _ = Describe("MessageReceiver", func() {
 				verifyErrorResponse(rr.Body, emptyDirectictiveErrorMsg)
 			})
 
+			It("Should allow sending a job without the payload field", func() {
+
+				postBody := "{\"account\": \"1234\", \"recipient\": \"345\", \"directive\": \"fred:flintstone\"}"
+
+				req, err := http.NewRequest("POST", MESSAGE_ENDPOINT, strings.NewReader(postBody))
+				Expect(err).NotTo(HaveOccurred())
+
+				req.Header.Add(IDENTITY_HEADER_NAME, validIdentityHeader)
+
+				rr := httptest.NewRecorder()
+
+				jr.router.ServeHTTP(rr, req)
+
+				Expect(rr.Code).To(Equal(http.StatusCreated))
+			})
 		})
 
 		Context("Without an identity header or pre shared key", func() {


### PR DESCRIPTION
## What?
The `payload` field for the post body of the v1 and v2 message endpoint is now optional.

[Jira ticket](https://issues.redhat.com/browse/RHCLOUD-20916)

## Why?
playbook-dispatcher's cancel operation needs to pass a `directive` that does not have a `payload` associated with it

## How?
Removed the `validate:"required"` json tags for the Payload fields.

## Testing
Tests added for both the v1 and v2 to demonstrate the behavior.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
