### PR TITLE
Bump the version in the grafana dashboard

### DIFF
--- a/dashboards/grafana-dashboard-insights-cloud-connector-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-cloud-connector-general.configmap.yaml
@@ -1845,7 +1845,7 @@ data:
       "timezone": "",
       "title": "Cloud-Connector",
       "uid": "c91dcda039618ded",
-      "version": 1,
+      "version": 2,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
Trying to determine why the updated dashboard isn't getting promoted.  Bump the version and see if it gets deployed.   I dunno...