### PR TITLE
modify 'allOf' to include additional fields [RHCLOUD-20714]

### DIFF
--- a/internal/controller/api/api.spec.json
+++ b/internal/controller/api/api.spec.json
@@ -621,30 +621,32 @@
           },
           {
             "$ref": "#/components/schemas/PaginatedResponseLinks"
-          }
-        ],
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "account": {
-                  "type": "string",
-                  "example": "0000001"
-                },
-                "connections": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "example": "node-a"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "account": {
+                      "type": "string",
+                      "example": "0000001"
+                    },
+                    "connections": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "node-a"
+                      }
+                    }
                   }
                 }
               }
             }
           }
-        }
+        ]
       },
       "ConnectionListAccountResponse": {
         "allOf": [
@@ -653,18 +655,20 @@
           },
           {
             "$ref": "#/components/schemas/PaginatedResponseLinks"
-          }
-        ],
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "example": "node-a"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "node-a"
+                }
+              }
             }
           }
-        }
+        ]
       },
       "ConnectionListByAccountResponseV2": {
         "allOf": [
@@ -673,17 +677,19 @@
           },
           {
             "$ref": "#/components/schemas/PaginatedResponseLinks"
-          }
-        ],
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConnectionV2"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ConnectionV2"
+                }
+              }
             }
           }
-        }
+        ]
       },
       "ConnectionV2": {
         "type": "object",
@@ -734,14 +740,16 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/ConnectionV2"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "$ref": "#/components/schemas/ConnectionStatus"
+              }
+            }
           }
-        ],
-        "type": "object",
-        "properties": {
-          "status": {
-            "$ref": "#/components/schemas/ConnectionStatus"
-          }
-        }
+        ]
       },
       "ConnectionPingResponse": {
         "type": "object",


### PR DESCRIPTION
## What?
Modify the OpenAPI schema json to include additional fields in schemas using `allOf`
[RHCLOUD-20714](https://issues.redhat.com/browse/RHCLOUD-20714)

## Why?
Allows the correct schema fields to be created by oapi-codegen

## How?
Modified the OpenAPI schema json to include additional fields in schemas using `allOf`

## Testing
Validated the OpenAPI spec and re-generated the files and then the missing fields were correctly generated.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
