### PR TITLE
Update ref to 3 scale dev deployment

### DIFF
--- a/deploy/template-prod.yml
+++ b/deploy/template-prod.yml
@@ -440,7 +440,7 @@ parameters:
   value: bop
 - name: AUTH_GATEWAY_URL
   required: true
-  value: "http://apicast.3scale-staging.svc.cluster.local:8890/internal/certauth"
+  value: "http://gateway.3scale-stage.svc.cluster.local:8890/internal/certauth"
 
 - name: SOURCES_RECORDER_IMPL
   required: true

--- a/deploy/template.yml
+++ b/deploy/template.yml
@@ -569,7 +569,7 @@ parameters:
   value: bop
 - name: AUTH_GATEWAY_URL
   required: true
-  value: "http://gateway.3scale-dev.svc.cluster.local:8890/internal/certauth"
+  value: "http://gateway.3scale-stage.svc.cluster.local:8890/internal/certauth"
 
 - name: SOURCES_RECORDER_IMPL
   required: true

--- a/deploy/template.yml
+++ b/deploy/template.yml
@@ -569,7 +569,7 @@ parameters:
   value: bop
 - name: AUTH_GATEWAY_URL
   required: true
-  value: "http://apicast.3scale-staging.svc.cluster.local:8890/internal/certauth"
+  value: "http://gateway.3scale-dev.svc.cluster.local:8890/internal/certauth"
 
 - name: SOURCES_RECORDER_IMPL
   required: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,7 +284,7 @@ func GetConfig() *Config {
 	options.SetDefault(JWT_TOKEN_EXPIRY, 1)
 	options.SetDefault(JWT_PRIVATE_KEY_FILE, "/etc/jwt/mqtt-private-key.rsa")
 	options.SetDefault(JWT_PUBLIC_KEY_FILE, "/etc/jwt/mqtt-public-key.rsa")
-	options.SetDefault(AUTH_GATEWAY_URL, "http://apicast.3scale-staging.svc.cluster.local:8890/internal/certauth")
+	options.SetDefault(AUTH_GATEWAY_URL, "http://gateway.3scale-stage.svc.cluster.local:8890/internal/certauth")
 	options.SetDefault(AUTH_GATEWAY_HTTP_CLIENT_TIMEOUT, 15)
 	options.SetDefault(RHC_MESSAGE_KAFKA_BROKERS, []string{DEFAULT_KAFKA_BROKER_ADDRESS})
 	options.SetDefault(RHC_MESSAGE_KAFKA_TOPIC, RHC_MESSAGE_KAFKA_TOPIC_DEFAULT)
@@ -298,7 +298,7 @@ func GetConfig() *Config {
 	options.SetDefault(API_SERVER_CONNECTION_LOOKUP_IMPL, "relaxed")
 	options.SetDefault(TENANT_TRANSLATOR_IMPL, "mock")
 	options.SetDefault(TENANT_TRANSLATOR_MOCK_MAPPING, map[string]string{"10001": "010101", "10000": "000000", "0002": "111000", "10002": "010102", "10003": "010103"})
-	options.SetDefault(TENANT_TRANSLATOR_URL, "http://apicast.3scale-dev.svc.cluster.local:8892")
+	options.SetDefault(TENANT_TRANSLATOR_URL, "http://gateway.3scale-dev.svc.cluster.local:8892")
 	options.SetDefault(TENANT_TRANSLATOR_TIMEOUT, 5)
 
 	options.SetEnvPrefix(ENV_PREFIX)


### PR DESCRIPTION
#### Jira Epic: https://issues.redhat.com/browse/RHCLOUD-20162
#### Jira Ticket: https://issues.redhat.com/browse/RHCLOUD-20960
----

## What?
Updating references from the old 3scale Dev and Stage deployments `apicast.3scale-(dev|stage).svc.cluster.local` to the new 3scale dev deployment `gateway.3scale-(dev|stage).svc.cluster.local`

## Why?
The reason for this change is the Infrastructure Team has stood up a new 3scale (Gateway) Deployment to support service serving certificates. Currently, both the old and new deployments are running in parallel so we can aid workstreams in the change over.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
