### PR TITLE
Modify the stale timestamp updater to use org_id as the main tenant id

### DIFF
--- a/internal/connection_repository/stale_connection_locator.go
+++ b/internal/connection_repository/stale_connection_locator.go
@@ -82,7 +82,7 @@ func UpdateStaleTimestampInDB(log *logrus.Entry, ctx context.Context, databaseCo
 	ctx, cancel := context.WithTimeout(ctx, sqlTimeout)
 	defer cancel()
 
-	update := "UPDATE connections SET stale_timestamp = NOW() WHERE account=$1 AND client_id=$2"
+	update := "UPDATE connections SET stale_timestamp = NOW() WHERE org_id=$1 AND client_id=$2"
 
 	statement, err := databaseConn.Prepare(update)
 	if err != nil {
@@ -90,7 +90,7 @@ func UpdateStaleTimestampInDB(log *logrus.Entry, ctx context.Context, databaseCo
 	}
 	defer statement.Close()
 
-	results, err := statement.ExecContext(ctx, rhcClient.Account, rhcClient.ClientID)
+	results, err := statement.ExecContext(ctx, rhcClient.OrgID, rhcClient.ClientID)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## What?
Modify the stale timestamp updater to use org_id as the main tenant id
[RHCLOUD-22877]

## Why?
We are not using the account number as the main tenant id any longer

## How?

## Testing
Manual testing
