### PR TITLE
Disable min 3 replicas rule for mqtt-message-consumer

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -122,6 +122,9 @@ objects:
 
 
     - name: mqtt-message-consumer
+      metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: "This deployment uses 1 pod, using more than 1 pod will lead to the ingestion of the same mqtt message multiple times"
       webServices:
         private:
           enabled: True


### PR DESCRIPTION
## What?
Disables the minimum 3 replicas requirement for mqtt  consumer.

## Why?
Using more than 1 replica for mqtt consumer will ingest the same mqtt message multiple times.

## How?
Added the `ignore-check.kube-linter.io/minimum-three-replicas` annotation for the mqtt-message-consumer pod.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
