### PR TITLE
Modify the mqtt consumer so that it sleeps for a bit after flushing the logs

### DIFF
--- a/cmd/cloud-connector/mqtt_message_consumer.go
+++ b/cmd/cloud-connector/mqtt_message_consumer.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/RedHatInsights/cloud-connector/internal/config"
 	"github.com/RedHatInsights/cloud-connector/internal/controller/api"
@@ -108,6 +109,12 @@ func startMqttMessageConsumer(mgmtAddr string) {
 	mqttClient.Disconnect(cfg.MqttDisconnectQuiesceTime)
 
 	kafkaProducer.Close()
+
+	logger.FlushLogger()
+
+	// This is kind of gross.  The idea here is to flush the logs and then
+	// sleep for a bit to make sure the logs are sent to cloudwatch.
+	time.Sleep(cfg.MqttConsumerShutdownSleepTime)
 
 	logger.Log.Info("Cloud-Connector shutting down")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ const (
 	MQTT_DATA_PUBLISH_QOS                        = "MQTT_Data_Publish_QoS"
 	MQTT_DISCONNECT_QUIESCE_TIME                 = "MQTT_Disconnect_Quiesce_Time"
 	MQTT_PUBLISH_TIMEOUT                         = "MQTT_Publish_Timeout"
+	MQTT_CONSUMER_SHUTDOWN_SLEEP_TIME            = "Mqtt_Consumer_Shutdown_Sleep_Time"
 	INVALID_HANDSHAKE_RECONNECT_DELAY            = "Invalid_Handshake_Reconnect_Delay"
 	CLIENT_ID_TO_ACCOUNT_ID_IMPL                 = "Client_Id_To_Account_Id_Impl"
 	CLIENT_ID_TO_ACCOUNT_ID_CONFIG_FILE          = "Client_Id_To_Account_Id_Config_File"
@@ -116,6 +117,7 @@ type Config struct {
 	MqttDataPublishQoS                      byte
 	MqttDisconnectQuiesceTime               uint
 	MqttPublishTimeout                      time.Duration
+	MqttConsumerShutdownSleepTime           time.Duration
 	InvalidHandshakeReconnectDelay          int
 	KafkaBrokers                            []string
 	KafkaCA                                 string
@@ -193,6 +195,7 @@ func (c Config) String() string {
 	fmt.Fprintf(&b, "%s: %d\n", MQTT_DATA_PUBLISH_QOS, c.MqttDataPublishQoS)
 	fmt.Fprintf(&b, "%s: %d\n", MQTT_DISCONNECT_QUIESCE_TIME, c.MqttDisconnectQuiesceTime)
 	fmt.Fprintf(&b, "%s: %s\n", MQTT_PUBLISH_TIMEOUT, c.MqttPublishTimeout)
+	fmt.Fprintf(&b, "%s: %s\n", MQTT_CONSUMER_SHUTDOWN_SLEEP_TIME, c.MqttConsumerShutdownSleepTime)
 	fmt.Fprintf(&b, "%s: %d\n", INVALID_HANDSHAKE_RECONNECT_DELAY, c.InvalidHandshakeReconnectDelay)
 	fmt.Fprintf(&b, "%s: %s\n", CLIENT_ID_TO_ACCOUNT_ID_IMPL, c.ClientIdToAccountIdImpl)
 	fmt.Fprintf(&b, "%s: %s\n", CLIENT_ID_TO_ACCOUNT_ID_CONFIG_FILE, c.ClientIdToAccountIdConfigFile)
@@ -260,6 +263,7 @@ func GetConfig() *Config {
 	options.SetDefault(MQTT_DATA_PUBLISH_QOS, 1)
 	options.SetDefault(MQTT_DISCONNECT_QUIESCE_TIME, 1000)
 	options.SetDefault(MQTT_PUBLISH_TIMEOUT, 2)
+	options.SetDefault(MQTT_CONSUMER_SHUTDOWN_SLEEP_TIME, 2)
 	options.SetDefault(INVALID_HANDSHAKE_RECONNECT_DELAY, 5)
 	options.SetDefault(CLIENT_ID_TO_ACCOUNT_ID_IMPL, "config_file_based")
 	options.SetDefault(CLIENT_ID_TO_ACCOUNT_ID_CONFIG_FILE, "client_id_to_account_id_map.json")
@@ -334,6 +338,7 @@ func GetConfig() *Config {
 		MqttDataPublishQoS:                      byte(options.GetInt(MQTT_DATA_PUBLISH_QOS)),
 		MqttDisconnectQuiesceTime:               options.GetUint(MQTT_DISCONNECT_QUIESCE_TIME),
 		MqttPublishTimeout:                      options.GetDuration(MQTT_PUBLISH_TIMEOUT) * time.Second,
+		MqttConsumerShutdownSleepTime:           options.GetDuration(MQTT_CONSUMER_SHUTDOWN_SLEEP_TIME) * time.Second,
 		InvalidHandshakeReconnectDelay:          options.GetInt(INVALID_HANDSHAKE_RECONNECT_DELAY),
 		ClientIdToAccountIdImpl:                 options.GetString(CLIENT_ID_TO_ACCOUNT_ID_IMPL),
 		ClientIdToAccountIdConfigFile:           options.GetString(CLIENT_ID_TO_ACCOUNT_ID_CONFIG_FILE),

--- a/internal/mqtt/message_handlers.go
+++ b/internal/mqtt/message_handlers.go
@@ -36,7 +36,8 @@ func ControlMessageHandler(ctx context.Context, kafkaWriter *kafka.Writer, topic
 
 		log := logger.Log.WithFields(logrus.Fields{"client_id": clientID,
 			"mqtt_message_id": mqttMessageID,
-			"duplicate":       message.Duplicate()})
+			"duplicate":       message.Duplicate(),
+			"topic":           message.Topic()})
 
 		if len(message.Payload()) == 0 {
 			// This will happen when a retained message is removed


### PR DESCRIPTION
## What?
Cloud-Connector already attempts to flush the logs on shutdown.  This change modifies the mqtt consumer to flush the logs and then sleep for a configurable amount of time.  Hopefully this will make it so that the last few log messages make it to cloudwatch.

## Why?
The last few log messages are not making it to cloudwatch.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
