### PR TITLE
Add PlatSec scan workflow

### DIFF
--- a/.github/workflows/security-workflow-template.yml
+++ b/.github/workflows/security-workflow-template.yml
@@ -1,0 +1,27 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow checks out code, builds an image, performs a container image
+# vulnerability scan with Anchore's Grype tool, and generates an
+# SBOM via Anchore's Syft tool
+
+# For more information on Anchore's container image scanning tool Grype, see
+# https://github.com/anchore/grype
+
+# For more information about the Anchore SBOM tool, Syft, see
+# https://github.com/anchore/syft
+
+name: ConsoleDot Platform Security Scan
+
+on:
+  push:
+    branches: [ "main", "master", "security-compliance" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main", "master", "security-compliance" ]
+
+jobs:
+  PlatSec-Security-Workflow:
+    uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use go-toolset as the builder image
 # Once built, copy to a smaller image and run from there
-FROM registry.redhat.io/ubi8/go-toolset as builder
+FROM registry.access.redhat.com/ubi8/go-toolset as builder
 
 WORKDIR /go/src/app
 
@@ -15,7 +15,7 @@ USER root
 RUN make build
 
 # Using ubi8-minimal due to its smaller footprint
-FROM registry.redhat.io/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /
 


### PR DESCRIPTION
Added security scan to github action based on [Platform Security GitHub Workflow
](https://github.com/RedHatInsights/platform-security-gh-workflow#platform-security-github-workflow) repo.

Modified the registry url based on the troubleshooting recommendation here: https://github.com/RedHatInsights/platform-security-gh-workflow#troubleshooting

Jira [RHCLOUD-27007](https://issues.redhat.com/browse/RHCLOUD-27007)

## What?
Add new script into the github workflow folder

## Why?
Provide a way to scan the container in a convenient, automated, and reliable manner within their GitHub repository.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
