### PR TITLE
Invalid Handshake Reconnect Delay to 60 seconds

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -333,6 +333,9 @@ objects:
         - name: CLOUD_CONNECTOR_SOURCES_BASE_URL
           value: ${{SOURCES_BASE_URL}}
 
+        - name: CLOUD_CONNECTOR_INVALID_HANDSHAKE_RECONNECT_DELAY
+          value: ${INVALID_HANDSHAKE_RECONNECT_DELAY}
+
 
     jobs:
 
@@ -568,6 +571,9 @@ parameters:
   value: "false"
 - name: API_SERVER_SHUTDOWN_ON_MQTT_CONNECTION_LOST
   value: "false"
+
+- name: INVALID_HANDSHAKE_RECONNECT_DELAY
+  value: "60"
 
 - name: RHC_MESSAGE_KAFKA_TOPIC
   required: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,7 +271,7 @@ func GetConfig() *Config {
 	options.SetDefault(MQTT_PUBLISH_TIMEOUT, 2)
 	options.SetDefault(MQTT_CONSUMER_SHUTDOWN_SLEEP_TIME, 2)
 	options.SetDefault(SHUTDOWN_ON_MQTT_CONNECTION_LOST, false)
-	options.SetDefault(INVALID_HANDSHAKE_RECONNECT_DELAY, 5)
+	options.SetDefault(INVALID_HANDSHAKE_RECONNECT_DELAY, 60)
 	options.SetDefault(CLIENT_ID_TO_ACCOUNT_ID_IMPL, "config_file_based")
 	options.SetDefault(CLIENT_ID_TO_ACCOUNT_ID_CONFIG_FILE, "client_id_to_account_id_map.json")
 	options.SetDefault(CLIENT_ID_TO_ACCOUNT_ID_DEFAULT_ACCOUNT_ID, "111000")


### PR DESCRIPTION
## What?
Explain what the change is linking any relevant JIRAs or Issues.
Changing the Invalid Handshake Reconnect Delay 
[RHCLOUD-28633]
## Why?
Consider what business or engineering goal does this PR achieves.
 This means that if a sends an online message but cloud-connector cannot map the client-id to an account/org-id then it cloud-connector will tell the client to reconnect in 60s
## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.
change the time from 5 seconds to 60 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x ] General Coding Practices
