### PR TITLE
Only log in the account mapper cache when running at the trace log level

### DIFF
--- a/internal/controller/account_resolver.go
+++ b/internal/controller/account_resolver.go
@@ -258,14 +258,14 @@ func (ecar *ExpirableCachedAccountIdResolver) MapClientIdToAccountId(ctx context
 		//Check if cached result is still valid
 		if result.err == nil {
 			metrics.accountLookupCacheHit.Inc()
-			logger.Debugf("Found cached account mapping results")
+			logger.Tracef("Found cached account mapping results")
 			return result.identity, result.accountID, result.orgID, nil
 		}
 
 		now := time.Now()
 		if now.Sub(result.timestamp) < ecar.errorTTL && result.err != nil {
 			metrics.accountLookupCacheHit.Inc()
-			logger.Debugf("Found cached account mapping results (error: %s)", result.err)
+			logger.Tracef("Found cached account mapping results (error: %s)", result.err)
 			//if cache error is within the error ttl return it
 			return "", "", "", result.err
 		}


### PR DESCRIPTION
I added the debug logging as another way to confirm that caching was working as expected since we really don't have way to test this outside of stage.  It seems to working as expected so I'm changing the log level to trace
