### PR TITLE
Sanitize the insights-id that is passed as a canonical fact

### DIFF
--- a/cmd/test_client/main.go
+++ b/cmd/test_client/main.go
@@ -150,7 +150,7 @@ func startProducer(certFile string, keyFile string, broker string, i int) {
 	sentTime := time.Now()
 
 	cf := Connector.CanonicalFacts{
-		InsightsID:            generateUUID(),
+		InsightsID:            "\u0000\u0000",
 		MachineID:             generateUUID(),
 		BiosID:                generateUUID(),
 		SubscriptionManagerID: generateUUID(),

--- a/internal/cloud_connector/message_handlers.go
+++ b/internal/cloud_connector/message_handlers.go
@@ -140,7 +140,7 @@ func handleOnlineMessage(logger *logrus.Entry, client MQTT.Client, clientID doma
 		Account:        account,
 		OrgID:          orgID,
 		Dispatchers:    handshakePayload[dispatchersKey],
-		CanonicalFacts: handshakePayload[canonicalFactsKey],
+		CanonicalFacts: sanitizeCanonicalFacts(handshakePayload[canonicalFactsKey]),
 		Tags:           handshakePayload[tagsKey],
 		MessageMetadata: domain.MessageMetadata{LatestMessageID: msg.MessageID,
 			LatestTimestamp: msg.Sent},

--- a/internal/cloud_connector/message_handlers_test.go
+++ b/internal/cloud_connector/message_handlers_test.go
@@ -196,7 +196,8 @@ func TestHandleDuplicateAndOldOnlineMessages(t *testing.T) {
 
 func buildOnlineMessage(t *testing.T, messageID string, sentTime time.Time) protocol.ControlMessage {
 	var connectionStatusPayload = "{\"state\":\"online\"}"
-	var content map[string]interface{}
+	content := make(map[string]interface{})
+	content["canonical_facts"] = map[string]interface{}{"insights_id": "fred"}
 
 	if err := json.Unmarshal([]byte(connectionStatusPayload), &content); err != nil {
 		t.Fatal(err)

--- a/internal/cloud_connector/utils.go
+++ b/internal/cloud_connector/utils.go
@@ -1,0 +1,28 @@
+package cloud_connector
+
+import (
+	"github.com/google/uuid"
+)
+
+func sanitizeCanonicalFacts(cf interface{}) interface{} {
+
+	canonicalFacts := cf.(map[string]interface{})
+	sanitizedCanonicalFacts := make(map[string]interface{})
+
+	for key, value := range canonicalFacts {
+		if key == "insights_id" {
+			if validUUID(value.(string)) {
+				sanitizedCanonicalFacts[key] = value
+			}
+		} else {
+			sanitizedCanonicalFacts[key] = value
+		}
+	}
+
+	return sanitizedCanonicalFacts
+}
+
+func validUUID(s string) bool {
+	_, err := uuid.Parse(s)
+	return err == nil
+}

--- a/internal/cloud_connector/utils_test.go
+++ b/internal/cloud_connector/utils_test.go
@@ -1,0 +1,61 @@
+package cloud_connector
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
+)
+
+func init() {
+	logger.InitLogger()
+}
+
+func TestSanitizeValidInsightsId(t *testing.T) {
+
+	canonicalFacts := make(map[string]interface{})
+	canonicalFacts["insights_id"] = "e20ea474-7287-4b68-80a6-533aa440e7bd"
+	canonicalFacts["bios_uuid"] = "e20ea474-7287-4b68-80a6-533aa440e7bd"
+	canonicalFacts["fqdn"] = "fred.flintstone.com"
+
+	sanitizedCanonicalFacts := sanitizeCanonicalFacts(canonicalFacts)
+
+	sanitizedCF := sanitizedCanonicalFacts.(map[string]interface{})
+
+	if canonicalFacts["insights_id"] != sanitizedCF["insights_id"] {
+		t.Fatal("insights_id was removed")
+	}
+
+	if canonicalFacts["bios_uuid"] != sanitizedCF["bios_uuid"] {
+		t.Fatal("bios_uuid was removed")
+	}
+
+	if canonicalFacts["fqdn"] != sanitizedCF["fqdn"] {
+		t.Fatal("fqdn was removed")
+	}
+
+}
+
+func TestSanitizeInvalidInsightsId(t *testing.T) {
+
+	canonicalFacts := make(map[string]interface{})
+	canonicalFacts["insights_id"] = "\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000"
+	canonicalFacts["bios_uuid"] = "e20ea474-7287-4b68-80a6-533aa440e7bd"
+	canonicalFacts["fqdn"] = "fred.flintstone.com"
+
+	sanitizedCanonicalFacts := sanitizeCanonicalFacts(canonicalFacts)
+
+	sanitizedCF := sanitizedCanonicalFacts.(map[string]interface{})
+
+	if _, ok := sanitizedCF["insights_id"]; ok {
+		t.Fatal("insights_id should have been removed")
+	}
+
+	if canonicalFacts["bios_uuid"] != sanitizedCF["bios_uuid"] {
+		t.Fatal("bios_uuid was removed")
+	}
+
+	if canonicalFacts["fqdn"] != sanitizedCF["fqdn"] {
+		t.Fatal("fqdn was removed")
+	}
+
+}


### PR DESCRIPTION
Sanitize the insights-id that is passed as a canonical fact.  If its invalid, remove it from the canonical facts (do not write it to the database, do not pass it to inventory)

## What?
Explain what the change is linking any relevant JIRAs or Issues.

## Why?
Consider what business or engineering goal does this PR achieves.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
