### PR TITLE
Run unit-test against master branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,11 @@
 name: PR Check
 
 on:
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    types: ["opened", "synchronize", "reopened"]
 
 jobs:
   test:


### PR DESCRIPTION
For metrics collection as QE, we like to run unit test against master branch. 
It will help us in  collect unit tests count as one important metrics for project situation metrics.
