### PR TITLE
Do not send reconnect message on org id lookup failures

### DIFF
--- a/internal/cloud_connector/message_handlers.go
+++ b/internal/cloud_connector/message_handlers.go
@@ -125,11 +125,11 @@ func handleOnlineMessage(logger *logrus.Entry, client MQTT.Client, clientID doma
 
 	identity, account, orgID, err := accountResolver.MapClientIdToAccountId(context.Background(), clientID)
 	if err != nil {
-		logger.WithFields(logrus.Fields{"error": err}).Error("Failed to resolve client id to account number")
+		logger.WithFields(logrus.Fields{"error": err}).Error("Failed to resolve client id to account number.")
+		logger.Info("Allowing tenant-less connection to continue with connection registration.")
 
-		mqtt.SendReconnectMessageToClient(client, logger, topicBuilder, cfg.MqttControlPublishQoS, cfg.MqttPublishTimeout, clientID, cfg.InvalidHandshakeReconnectDelay)
-
-		return nil
+		// Allow a tenant-less connection to continue to get registered
+		// We will attempt to fix this situation later
 	}
 
 	logger = logger.WithFields(logrus.Fields{"account": account, "org_id": orgID})

--- a/internal/connection_repository/sql_connection_locator_v2.go
+++ b/internal/connection_repository/sql_connection_locator_v2.go
@@ -16,7 +16,7 @@ const (
 	satelliteWorker              = "foreman_rh_cloud"
 	connectionQueryPrefix        = "SELECT  account, org_id, dispatchers, canonical_facts, tags FROM connections "
 	strictConnectionLookupQuery  = connectionQueryPrefix + "WHERE org_id = $1 AND client_id = $2"
-	relaxedConnectionLookupQuery = connectionQueryPrefix + "WHERE (org_id = $1 OR dispatchers ? '" + satelliteWorker + "') AND client_id = $2"
+	relaxedConnectionLookupQuery = connectionQueryPrefix + "WHERE (org_id = $1 OR dispatchers ? '" + satelliteWorker + "') AND org_id != '' AND client_id = $2"
 )
 
 func NewSqlGetConnectionByClientID(cfg *config.Config, database *sql.DB) (GetConnectionByClientID, error) {

--- a/internal/connection_repository/sql_connection_locator_v2.go
+++ b/internal/connection_repository/sql_connection_locator_v2.go
@@ -15,8 +15,8 @@ import (
 const (
 	satelliteWorker              = "foreman_rh_cloud"
 	connectionQueryPrefix        = "SELECT  account, org_id, dispatchers, canonical_facts, tags FROM connections "
-	strictConnectionLookupQuery  = connectionQueryPrefix + "WHERE org_id = $1 AND client_id = $2"
-	relaxedConnectionLookupQuery = connectionQueryPrefix + "WHERE (org_id = $1 OR dispatchers ? '" + satelliteWorker + "') AND org_id != '' AND client_id = $2"
+	strictConnectionLookupQuery  = connectionQueryPrefix + "WHERE org_id = $1 AND client_id = $2 AND org_id != '' "
+	relaxedConnectionLookupQuery = connectionQueryPrefix + "WHERE (org_id = $1 OR dispatchers ? '" + satelliteWorker + "') AND org_id != '' AND client_id = $2 "
 )
 
 func NewSqlGetConnectionByClientID(cfg *config.Config, database *sql.DB) (GetConnectionByClientID, error) {

--- a/internal/connection_repository/sql_connection_locator_v2.go
+++ b/internal/connection_repository/sql_connection_locator_v2.go
@@ -124,6 +124,11 @@ func NewSqlGetConnectionsByOrgID(cfg *config.Config, database *sql.DB) (GetConne
 
 		var totalConnections int
 
+		err := verifyOrgId(orgId)
+		if err != nil {
+			return nil, 0, err
+		}
+
 		callDurationTimer := prometheus.NewTimer(metrics.sqlLookupConnectionsByAccountDuration)
 		defer callDurationTimer.ObserveDuration()
 
@@ -201,7 +206,7 @@ func NewGetAllConnections(cfg *config.Config, database *sql.DB) (GetAllConnectio
 
 		statement, err := database.Prepare(
 			`SELECT account, org_id, client_id, canonical_facts, dispatchers, tags, COUNT(*) OVER() FROM connections
-				ORDER BY account, client_id
+				ORDER BY org_id, client_id
 				OFFSET $1
 				LIMIT $2`)
 		if err != nil {

--- a/internal/connection_repository/sql_connection_locator_v2_test.go
+++ b/internal/connection_repository/sql_connection_locator_v2_test.go
@@ -5,6 +5,7 @@ package connection_repository
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"testing"
 
@@ -20,6 +21,16 @@ func init() {
 	logger.InitLogger()
 }
 
+type connectionLocatorV2TestCaseData struct {
+	testName       string
+	orgID          domain.OrgID
+	account        domain.AccountID
+	clientID       domain.ClientID
+	dispatchers    string
+	requestedOrgID domain.OrgID
+	expectedError  error
+}
+
 func TestSqlConnectionLocatorV2StrictImplementation(t *testing.T) {
 
 	cfg := config.GetConfig()
@@ -31,73 +42,20 @@ func TestSqlConnectionLocatorV2StrictImplementation(t *testing.T) {
 
 	getConnectionByClientID, err := NewSqlGetConnectionByClientID(cfg, database)
 
-	testCases := []struct {
-		testName       string
-		orgID          domain.OrgID
-		account        domain.AccountID
-		clientID       domain.ClientID
-		dispatchers    string
-		requestedOrgID domain.OrgID
-		expectedError  error
-	}{
-		{"with no dispatchers", "999991", "999999", "sql-locator-v2-strict-test-client-1", "{}", "999991", nil},
-		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}", "888881", nil},
-		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-3", "{\"satellite\": {\"version\": \"0.2\"}}", "different_should_miss", NotFoundError},
-		{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_miss_too", NotFoundError},
-		{"with no account", "", "999992", "sql-locator-v2-strict-test-client-5", "{}", "9999", NotFoundError},                                                                                             // anemic tenant
-		{"with no account or org-id", "", "", "sql-locator-v2-strict-test-client-6", "{}", "9999", NotFoundError},                                                                                         // ghost connection
-		{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-strict-test-client-5", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
-		{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-strict-test-client-6", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
+	testCases := []connectionLocatorV2TestCaseData{
+		connectionLocatorV2TestCaseData{"with no dispatchers", "999991", "999999", "sql-locator-v2-strict-test-client-1", "{}", "999991", nil},
+		connectionLocatorV2TestCaseData{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}", "888881", nil},
+		connectionLocatorV2TestCaseData{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-3", "{\"satellite\": {\"version\": \"0.2\"}}", "different_should_miss", NotFoundError},
+		connectionLocatorV2TestCaseData{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_miss_too", NotFoundError},
+		connectionLocatorV2TestCaseData{"with no account", "", "999992", "sql-locator-v2-strict-test-client-5", "{}", "9999", NotFoundError},                                                                                             // anemic tenant
+		connectionLocatorV2TestCaseData{"with no account or org-id", "", "", "sql-locator-v2-strict-test-client-6", "{}", "9999", NotFoundError},                                                                                         // ghost connection
+		connectionLocatorV2TestCaseData{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-strict-test-client-5", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
+		connectionLocatorV2TestCaseData{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-strict-test-client-6", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-
-			log := logger.Log.WithFields(logrus.Fields{"test_name": tc.testName})
-
-			var dispatchers map[string]interface{}
-			err := json.Unmarshal([]byte(tc.dispatchers), &dispatchers)
-			if err != nil {
-				t.Fatal("unexpected error while creating dispatchers json doc", err)
-			}
-
-			var connectionRegistrar ConnectionRegistrar
-			connectionRegistrar, err = NewSqlConnectionRegistrar(cfg, database)
-			if err != nil {
-				t.Fatal("unexpected error while creating the SqlConnectionRegistrar", err)
-			}
-
-			connectorClientState := domain.ConnectorClientState{
-				OrgID:       tc.orgID,
-				Account:     tc.account,
-				ClientID:    tc.clientID,
-				Dispatchers: dispatchers,
-			}
-
-			err = connectionRegistrar.Register(context.TODO(), connectorClientState)
-			if err != nil {
-				t.Fatal("unexpected error while registering a connection", err)
-			}
-
-			actualClientState, err := getConnectionByClientID(context.TODO(), log, tc.requestedOrgID, tc.clientID)
-			if err != tc.expectedError {
-				t.Fatal("unexpected error while looking up a connection", err)
-			}
-
-			if err != NotFoundError {
-				verifyConnectorClientState(t, connectorClientState, actualClientState)
-			}
-
-			err = connectionRegistrar.Unregister(context.TODO(), tc.clientID)
-			if err != nil {
-				t.Fatal("unexpected error while registering a connection", err)
-			}
-
-			_, err = connectionRegistrar.FindConnectionByClientID(context.TODO(), tc.clientID)
-			if err != NotFoundError {
-				t.Fatal("found a connection when the connection was not supposed to exist", err)
-			}
-
+			runSqlConnectionLocatorV2Test(t, tc, cfg, database, getConnectionByClientID)
 		})
 	}
 }
@@ -113,73 +71,68 @@ func TestSqlConnectionLocatorV2RelaxedImplementation(t *testing.T) {
 
 	getConnectionByClientID, err := NewPermittedTenantSqlGetConnectionByClientID(cfg, database)
 
-	testCases := []struct {
-		testName       string
-		orgID          domain.OrgID
-		account        domain.AccountID
-		clientID       domain.ClientID
-		dispatchers    string
-		requestedOrgID domain.OrgID
-		expectedError  error
-	}{
-		{"with no dispatchers", "999991", "999999", "sql-locator-v2-test-client-1", "{}", "999991", nil},
-		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}", "888881", nil},
-		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-3", "{\"satellite\": {\"version\": \"0.2\"}}", "different_should_miss", NotFoundError},
-		{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_match", nil},
-		{"with no account", "", "999992", "sql-locator-v2-test-client-5", "{}", "9999", NotFoundError},                                                                                             // anemic tenant
-		{"with no account or org-id", "", "", "sql-locator-v2-test-client-6", "{}", "9999", NotFoundError},                                                                                         // ghost connection
-		{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-test-client-5", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
-		{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-test-client-6", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
+	testCases := []connectionLocatorV2TestCaseData{
+		connectionLocatorV2TestCaseData{"with no dispatchers", "999991", "999999", "sql-locator-v2-test-client-1", "{}", "999991", nil},
+		connectionLocatorV2TestCaseData{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}", "888881", nil},
+		connectionLocatorV2TestCaseData{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-3", "{\"satellite\": {\"version\": \"0.2\"}}", "different_should_miss", NotFoundError},
+		connectionLocatorV2TestCaseData{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_match", nil},
+		connectionLocatorV2TestCaseData{"with no account", "", "999992", "sql-locator-v2-test-client-5", "{}", "9999", NotFoundError},                                                                                             // anemic tenant
+		connectionLocatorV2TestCaseData{"with no account or org-id", "", "", "sql-locator-v2-test-client-6", "{}", "9999", NotFoundError},                                                                                         // ghost connection
+		connectionLocatorV2TestCaseData{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-test-client-5", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
+		connectionLocatorV2TestCaseData{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-test-client-6", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-
-			log := logger.Log.WithFields(logrus.Fields{"test_name": tc.testName})
-
-			var dispatchers map[string]interface{}
-			err := json.Unmarshal([]byte(tc.dispatchers), &dispatchers)
-			if err != nil {
-				t.Fatal("unexpected error while creating dispatchers json doc", err)
-			}
-
-			var connectionRegistrar ConnectionRegistrar
-			connectionRegistrar, err = NewSqlConnectionRegistrar(cfg, database)
-			if err != nil {
-				t.Fatal("unexpected error while creating the SqlConnectionRegistrar", err)
-			}
-
-			connectorClientState := domain.ConnectorClientState{
-				OrgID:       tc.orgID,
-				Account:     tc.account,
-				ClientID:    tc.clientID,
-				Dispatchers: dispatchers,
-			}
-
-			err = connectionRegistrar.Register(context.TODO(), connectorClientState)
-			if err != nil {
-				t.Fatal("unexpected error while registering a connection", err)
-			}
-
-			actualClientState, err := getConnectionByClientID(context.TODO(), log, tc.requestedOrgID, tc.clientID)
-			if err != tc.expectedError {
-				t.Fatal("unexpected error while looking up a connection", err)
-			}
-
-			if err != NotFoundError {
-				verifyConnectorClientState(t, connectorClientState, actualClientState)
-			}
-
-			err = connectionRegistrar.Unregister(context.TODO(), tc.clientID)
-			if err != nil {
-				t.Fatal("unexpected error while registering a connection", err)
-			}
-
-			_, err = connectionRegistrar.FindConnectionByClientID(context.TODO(), tc.clientID)
-			if err != NotFoundError {
-				t.Fatal("found a connection when the connection was not supposed to exist", err)
-			}
-
+			runSqlConnectionLocatorV2Test(t, tc, cfg, database, getConnectionByClientID)
 		})
+	}
+}
+
+func runSqlConnectionLocatorV2Test(t *testing.T, tc connectionLocatorV2TestCaseData, cfg *config.Config, database *sql.DB, getConnectionByClientID GetConnectionByClientID) {
+
+	log := logger.Log.WithFields(logrus.Fields{"test_name": tc.testName})
+
+	var dispatchers map[string]interface{}
+	err := json.Unmarshal([]byte(tc.dispatchers), &dispatchers)
+	if err != nil {
+		t.Fatal("unexpected error while creating dispatchers json doc", err)
+	}
+
+	var connectionRegistrar ConnectionRegistrar
+	connectionRegistrar, err = NewSqlConnectionRegistrar(cfg, database)
+	if err != nil {
+		t.Fatal("unexpected error while creating the SqlConnectionRegistrar", err)
+	}
+
+	connectorClientState := domain.ConnectorClientState{
+		OrgID:       tc.orgID,
+		Account:     tc.account,
+		ClientID:    tc.clientID,
+		Dispatchers: dispatchers,
+	}
+
+	err = connectionRegistrar.Register(context.TODO(), connectorClientState)
+	if err != nil {
+		t.Fatal("unexpected error while registering a connection", err)
+	}
+
+	actualClientState, err := getConnectionByClientID(context.TODO(), log, tc.requestedOrgID, tc.clientID)
+	if err != tc.expectedError {
+		t.Fatal("unexpected error while looking up a connection", err)
+	}
+
+	if err != NotFoundError {
+		verifyConnectorClientState(t, connectorClientState, actualClientState)
+	}
+
+	err = connectionRegistrar.Unregister(context.TODO(), tc.clientID)
+	if err != nil {
+		t.Fatal("unexpected error while registering a connection", err)
+	}
+
+	_, err = connectionRegistrar.FindConnectionByClientID(context.TODO(), tc.clientID)
+	if err != NotFoundError {
+		t.Fatal("found a connection when the connection was not supposed to exist", err)
 	}
 }

--- a/internal/connection_repository/sql_connection_locator_v2_test.go
+++ b/internal/connection_repository/sql_connection_locator_v2_test.go
@@ -49,8 +49,9 @@ func TestSqlConnectionLocatorV2StrictImplementation(t *testing.T) {
 		connectionLocatorV2TestCaseData{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_miss_too", NotFoundError},
 		connectionLocatorV2TestCaseData{"with no account", "", "999992", "sql-locator-v2-strict-test-client-5", "{}", "9999", NotFoundError},                                                                                             // anemic tenant
 		connectionLocatorV2TestCaseData{"with no account or org-id", "", "", "sql-locator-v2-strict-test-client-6", "{}", "9999", NotFoundError},                                                                                         // ghost connection
-		connectionLocatorV2TestCaseData{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-strict-test-client-5", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
-		connectionLocatorV2TestCaseData{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-strict-test-client-6", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
+		connectionLocatorV2TestCaseData{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-strict-test-client-7", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
+		connectionLocatorV2TestCaseData{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-strict-test-client-8", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
+		connectionLocatorV2TestCaseData{"with empty requested org-id", "99999", "99999", "sql-locator-v2-strict-test-client-9", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "", InvalidOrgIDError},
 	}
 
 	for _, tc := range testCases {
@@ -72,14 +73,15 @@ func TestSqlConnectionLocatorV2RelaxedImplementation(t *testing.T) {
 	getConnectionByClientID, err := NewPermittedTenantSqlGetConnectionByClientID(cfg, database)
 
 	testCases := []connectionLocatorV2TestCaseData{
-		connectionLocatorV2TestCaseData{"with no dispatchers", "999991", "999999", "sql-locator-v2-test-client-1", "{}", "999991", nil},
-		connectionLocatorV2TestCaseData{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}", "888881", nil},
-		connectionLocatorV2TestCaseData{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-3", "{\"satellite\": {\"version\": \"0.2\"}}", "different_should_miss", NotFoundError},
-		connectionLocatorV2TestCaseData{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_match", nil},
-		connectionLocatorV2TestCaseData{"with no account", "", "999992", "sql-locator-v2-test-client-5", "{}", "9999", NotFoundError},                                                                                             // anemic tenant
-		connectionLocatorV2TestCaseData{"with no account or org-id", "", "", "sql-locator-v2-test-client-6", "{}", "9999", NotFoundError},                                                                                         // ghost connection
-		connectionLocatorV2TestCaseData{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-test-client-5", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
-		connectionLocatorV2TestCaseData{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-test-client-6", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
+		connectionLocatorV2TestCaseData{"with no dispatchers", "999991", "999999", "sql-locator-v2-relaxed-test-client-1", "{}", "999991", nil},
+		connectionLocatorV2TestCaseData{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-relaxed-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}", "888881", nil},
+		connectionLocatorV2TestCaseData{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-relaxed-test-client-3", "{\"satellite\": {\"version\": \"0.2\"}}", "different_should_miss", NotFoundError},
+		connectionLocatorV2TestCaseData{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-relaxed-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_match", nil},
+		connectionLocatorV2TestCaseData{"with no account", "", "999992", "sql-locator-v2-relaxed-test-client-5", "{}", "9999", NotFoundError},                                                                                             // anemic tenant
+		connectionLocatorV2TestCaseData{"with no account or org-id", "", "", "sql-locator-v2-relaxed-test-client-6", "{}", "9999", NotFoundError},                                                                                         // ghost connection
+		connectionLocatorV2TestCaseData{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-relaxed-test-client-7", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
+		connectionLocatorV2TestCaseData{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-relaxed-test-client-8", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
+		connectionLocatorV2TestCaseData{"with empty requested org-id", "99999", "99999", "sql-locator-v2-relaxed-test-client-9", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "", InvalidOrgIDError},
 	}
 
 	for _, tc := range testCases {
@@ -122,7 +124,7 @@ func runSqlConnectionLocatorV2Test(t *testing.T, tc connectionLocatorV2TestCaseD
 		t.Fatal("unexpected error while looking up a connection", err)
 	}
 
-	if err != NotFoundError {
+	if err != NotFoundError && err != InvalidOrgIDError {
 		verifyConnectorClientState(t, connectorClientState, actualClientState)
 	}
 

--- a/internal/connection_repository/sql_connection_locator_v2_test.go
+++ b/internal/connection_repository/sql_connection_locator_v2_test.go
@@ -1,0 +1,101 @@
+//go:build sql
+// +build sql
+
+package connection_repository
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/RedHatInsights/cloud-connector/internal/config"
+	"github.com/RedHatInsights/cloud-connector/internal/domain"
+	"github.com/RedHatInsights/cloud-connector/internal/platform/db"
+	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
+
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	logger.InitLogger()
+}
+
+func TestSqlConnectionLocatorV2PermittedTenant(t *testing.T) {
+
+	cfg := config.GetConfig()
+
+	database, err := db.InitializeDatabaseConnection(cfg)
+	if err != nil {
+		t.Fatal("Unable to connect to database: ", err)
+	}
+
+	getConnectionByClientID, err := NewPermittedTenantSqlGetConnectionByClientID(cfg, database)
+
+	testCases := []struct {
+		testName       string
+		orgID          domain.OrgID
+		account        domain.AccountID
+		clientID       domain.ClientID
+		dispatchers    string
+		requestedOrgID domain.OrgID
+		expectedError  error
+	}{
+		{"with no dispatchers", "999991", "999999", "sql-locator-v2-test-client-1", "{}", "999991", nil},
+		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}", "888881", nil},
+		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-3", "{\"satellite\": {\"version\": \"0.2\"}}", "different_should_miss", NotFoundError},
+		{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_match", nil},
+		{"with no account", "", "999992", "sql-locator-v2-test-client-5", "{}", "9999", NotFoundError},     // anemic tenant
+		{"with no account or org-id", "", "", "sql-locator-v2-test-client-6", "{}", "9999", NotFoundError}, // ghost connection
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+
+			log := logger.Log.WithFields(logrus.Fields{"test_name": tc.testName})
+
+			var dispatchers map[string]interface{}
+			err := json.Unmarshal([]byte(tc.dispatchers), &dispatchers)
+			if err != nil {
+				t.Fatal("unexpected error while creating dispatchers json doc", err)
+			}
+
+			var connectionRegistrar ConnectionRegistrar
+			connectionRegistrar, err = NewSqlConnectionRegistrar(cfg, database)
+			if err != nil {
+				t.Fatal("unexpected error while creating the SqlConnectionRegistrar", err)
+			}
+
+			connectorClientState := domain.ConnectorClientState{
+				OrgID:       tc.orgID,
+				Account:     tc.account,
+				ClientID:    tc.clientID,
+				Dispatchers: dispatchers,
+			}
+
+			err = connectionRegistrar.Register(context.TODO(), connectorClientState)
+			if err != nil {
+				t.Fatal("unexpected error while registering a connection", err)
+			}
+
+			actualClientState, err := getConnectionByClientID(context.TODO(), log, tc.requestedOrgID, tc.clientID)
+			if err != tc.expectedError {
+				t.Fatal("unexpected error while looking up a connection", err)
+			}
+
+			if err != NotFoundError {
+				verifyConnectorClientState(t, connectorClientState, actualClientState)
+			}
+
+			err = connectionRegistrar.Unregister(context.TODO(), tc.clientID)
+			if err != nil {
+				t.Fatal("unexpected error while registering a connection", err)
+			}
+
+			_, err = connectionRegistrar.FindConnectionByClientID(context.TODO(), tc.clientID)
+			if err != NotFoundError {
+				t.Fatal("found a connection when the connection was not supposed to exist", err)
+			}
+
+		})
+	}
+}

--- a/internal/connection_repository/sql_connection_locator_v2_test.go
+++ b/internal/connection_repository/sql_connection_locator_v2_test.go
@@ -20,7 +20,89 @@ func init() {
 	logger.InitLogger()
 }
 
-func TestSqlConnectionLocatorV2PermittedTenant(t *testing.T) {
+func TestSqlConnectionLocatorV2StrictImplementation(t *testing.T) {
+
+	cfg := config.GetConfig()
+
+	database, err := db.InitializeDatabaseConnection(cfg)
+	if err != nil {
+		t.Fatal("Unable to connect to database: ", err)
+	}
+
+	getConnectionByClientID, err := NewSqlGetConnectionByClientID(cfg, database)
+
+	testCases := []struct {
+		testName       string
+		orgID          domain.OrgID
+		account        domain.AccountID
+		clientID       domain.ClientID
+		dispatchers    string
+		requestedOrgID domain.OrgID
+		expectedError  error
+	}{
+		{"with no dispatchers", "999991", "999999", "sql-locator-v2-strict-test-client-1", "{}", "999991", nil},
+		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}", "888881", nil},
+		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-3", "{\"satellite\": {\"version\": \"0.2\"}}", "different_should_miss", NotFoundError},
+		{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-strict-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_miss_too", NotFoundError},
+		{"with no account", "", "999992", "sql-locator-v2-strict-test-client-5", "{}", "9999", NotFoundError},                                                                                             // anemic tenant
+		{"with no account or org-id", "", "", "sql-locator-v2-strict-test-client-6", "{}", "9999", NotFoundError},                                                                                         // ghost connection
+		{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-strict-test-client-5", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
+		{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-strict-test-client-6", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+
+			log := logger.Log.WithFields(logrus.Fields{"test_name": tc.testName})
+
+			var dispatchers map[string]interface{}
+			err := json.Unmarshal([]byte(tc.dispatchers), &dispatchers)
+			if err != nil {
+				t.Fatal("unexpected error while creating dispatchers json doc", err)
+			}
+
+			var connectionRegistrar ConnectionRegistrar
+			connectionRegistrar, err = NewSqlConnectionRegistrar(cfg, database)
+			if err != nil {
+				t.Fatal("unexpected error while creating the SqlConnectionRegistrar", err)
+			}
+
+			connectorClientState := domain.ConnectorClientState{
+				OrgID:       tc.orgID,
+				Account:     tc.account,
+				ClientID:    tc.clientID,
+				Dispatchers: dispatchers,
+			}
+
+			err = connectionRegistrar.Register(context.TODO(), connectorClientState)
+			if err != nil {
+				t.Fatal("unexpected error while registering a connection", err)
+			}
+
+			actualClientState, err := getConnectionByClientID(context.TODO(), log, tc.requestedOrgID, tc.clientID)
+			if err != tc.expectedError {
+				t.Fatal("unexpected error while looking up a connection", err)
+			}
+
+			if err != NotFoundError {
+				verifyConnectorClientState(t, connectorClientState, actualClientState)
+			}
+
+			err = connectionRegistrar.Unregister(context.TODO(), tc.clientID)
+			if err != nil {
+				t.Fatal("unexpected error while registering a connection", err)
+			}
+
+			_, err = connectionRegistrar.FindConnectionByClientID(context.TODO(), tc.clientID)
+			if err != NotFoundError {
+				t.Fatal("found a connection when the connection was not supposed to exist", err)
+			}
+
+		})
+	}
+}
+
+func TestSqlConnectionLocatorV2RelaxedImplementation(t *testing.T) {
 
 	cfg := config.GetConfig()
 

--- a/internal/connection_repository/sql_connection_locator_v2_test.go
+++ b/internal/connection_repository/sql_connection_locator_v2_test.go
@@ -44,8 +44,10 @@ func TestSqlConnectionLocatorV2PermittedTenant(t *testing.T) {
 		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}", "888881", nil},
 		{"with satellite dispatchers", "888881", "888888", "sql-locator-v2-test-client-3", "{\"satellite\": {\"version\": \"0.2\"}}", "different_should_miss", NotFoundError},
 		{"with " + satelliteWorker + " dispatchers", "888881", "888888", "sql-locator-v2-test-client-4", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "different_should_match", nil},
-		{"with no account", "", "999992", "sql-locator-v2-test-client-5", "{}", "9999", NotFoundError},     // anemic tenant
-		{"with no account or org-id", "", "", "sql-locator-v2-test-client-6", "{}", "9999", NotFoundError}, // ghost connection
+		{"with no account", "", "999992", "sql-locator-v2-test-client-5", "{}", "9999", NotFoundError},                                                                                             // anemic tenant
+		{"with no account or org-id", "", "", "sql-locator-v2-test-client-6", "{}", "9999", NotFoundError},                                                                                         // ghost connection
+		{"with no account with " + satelliteWorker + " dispatchers", "", "999992", "sql-locator-v2-test-client-5", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError}, // anemic tenant
+		{"with no account or org-id " + satelliteWorker + " dispatchers", "", "", "sql-locator-v2-test-client-6", "{\"" + satelliteWorker + "\": {\"version\": \"0.2\"}}", "9999", NotFoundError},  // ghost connection
 	}
 
 	for _, tc := range testCases {

--- a/internal/connection_repository/sql_connection_registrar.go
+++ b/internal/connection_repository/sql_connection_registrar.go
@@ -42,7 +42,7 @@ func (scm *SqlConnectionRegistrar) Register(ctx context.Context, rhcClient domai
 
 	logger := logger.Log.WithFields(logrus.Fields{"account": account, "org_id": org_id, "client_id": client_id})
 
-	update := "UPDATE connections SET dispatchers=$1, tags = $2, updated_at = NOW(), message_id = $3, message_sent = $4 WHERE account=$5 AND client_id=$6"
+	update := "UPDATE connections SET dispatchers=$1, tags = $2, updated_at = NOW(), message_id = $3, message_sent = $4 WHERE org_id=$5 AND client_id=$6"
 	insert := "INSERT INTO connections (account, org_id, client_id, dispatchers, canonical_facts, tags, message_id, message_sent) SELECT $7, $8, $9, $10, $11, $12, $13, $14"
 
 	insertOrUpdate := fmt.Sprintf("WITH upsert AS (%s RETURNING *) %s WHERE NOT EXISTS (SELECT * FROM upsert)", update, insert)
@@ -72,7 +72,7 @@ func (scm *SqlConnectionRegistrar) Register(ctx context.Context, rhcClient domai
 		return err
 	}
 
-	_, err = statement.ExecContext(ctx, dispatchersString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp, account, client_id, account, org_id, client_id, dispatchersString, canonicalFactsString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp)
+	_, err = statement.ExecContext(ctx, dispatchersString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp, org_id, client_id, account, org_id, client_id, dispatchersString, canonicalFactsString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp)
 	if err != nil {
 		logger.WithFields(logrus.Fields{"error": err}).Error("Insert/update failed")
 		return FatalError{err}

--- a/internal/connection_repository/sql_connection_registrar.go
+++ b/internal/connection_repository/sql_connection_registrar.go
@@ -42,8 +42,8 @@ func (scm *SqlConnectionRegistrar) Register(ctx context.Context, rhcClient domai
 
 	logger := logger.Log.WithFields(logrus.Fields{"account": account, "org_id": org_id, "client_id": client_id})
 
-	update := "UPDATE connections SET dispatchers=$1, tags = $2, updated_at = NOW(), message_id = $3, message_sent = $4 WHERE org_id=$5 AND client_id=$6"
-	insert := "INSERT INTO connections (account, org_id, client_id, dispatchers, canonical_facts, tags, message_id, message_sent) SELECT $7, $8, $9, $10, $11, $12, $13, $14"
+	update := "UPDATE connections SET dispatchers=$1, tags = $2, updated_at = NOW(), message_id = $3, message_sent = $4, org_id = $5, account = $6 WHERE client_id=$7"
+	insert := "INSERT INTO connections (account, org_id, client_id, dispatchers, canonical_facts, tags, message_id, message_sent) SELECT $8, $9, $10, $11, $12, $13, $14, $15"
 
 	insertOrUpdate := fmt.Sprintf("WITH upsert AS (%s RETURNING *) %s WHERE NOT EXISTS (SELECT * FROM upsert)", update, insert)
 
@@ -72,7 +72,7 @@ func (scm *SqlConnectionRegistrar) Register(ctx context.Context, rhcClient domai
 		return err
 	}
 
-	_, err = statement.ExecContext(ctx, dispatchersString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp, org_id, client_id, account, org_id, client_id, dispatchersString, canonicalFactsString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp)
+	_, err = statement.ExecContext(ctx, dispatchersString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp, org_id, account, client_id, account, org_id, client_id, dispatchersString, canonicalFactsString, tagsString, rhcClient.MessageMetadata.LatestMessageID, rhcClient.MessageMetadata.LatestTimestamp)
 	if err != nil {
 		logger.WithFields(logrus.Fields{"error": err}).Error("Insert/update failed")
 		return FatalError{err}

--- a/internal/connection_repository/sql_connection_registrar_test.go
+++ b/internal/connection_repository/sql_connection_registrar_test.go
@@ -88,6 +88,10 @@ func TestSqlConnectionRegistrar(t *testing.T) {
 	}
 }
 
+func TestSqlConnectionRegistrarUpdateTenantlessConnection(t *testing.T) {
+	t.Fatal("Implement this test!!", nil)
+}
+
 func verifyConnectorClientState(t *testing.T, expectedClientState, actualClientState domain.ConnectorClientState) {
 	if expectedClientState.Account != actualClientState.Account ||
 		expectedClientState.OrgID != actualClientState.OrgID ||

--- a/internal/connection_repository/sql_connection_registrar_test.go
+++ b/internal/connection_repository/sql_connection_registrar_test.go
@@ -29,12 +29,15 @@ func TestSqlConnectionRegistrar(t *testing.T) {
 
 	testCases := []struct {
 		testName    string
+		orgID       domain.OrgID
 		account     domain.AccountID
 		clientID    domain.ClientID
 		dispatchers string
 	}{
-		{"with no dispatchers", "999999", "registrar-test-client-1", "{}"},
-		{"with satellite dispatchers", "888888", "registrar-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}"},
+		{"with no dispatchers", "999991", "999999", "registrar-test-client-1", "{}"},
+		{"with satellite dispatchers", "888881", "888888", "registrar-test-client-2", "{\"satellite\": {\"version\": \"0.2\"}}"},
+		{"with no account", "", "999992", "registrar-test-client-3", "{}"},     // anemic tenant
+		{"with no account or org-id", "", "", "registrar-test-client-4", "{}"}, // ghost connection
 	}
 
 	for _, tc := range testCases {
@@ -53,6 +56,7 @@ func TestSqlConnectionRegistrar(t *testing.T) {
 			}
 
 			connectorClientState := domain.ConnectorClientState{
+				OrgID:       tc.orgID,
 				Account:     tc.account,
 				ClientID:    tc.clientID,
 				Dispatchers: dispatchers,
@@ -86,6 +90,7 @@ func TestSqlConnectionRegistrar(t *testing.T) {
 
 func verifyConnectorClientState(t *testing.T, expectedClientState, actualClientState domain.ConnectorClientState) {
 	if expectedClientState.Account != actualClientState.Account ||
+		expectedClientState.OrgID != actualClientState.OrgID ||
 		expectedClientState.ClientID != actualClientState.ClientID {
 		t.Fatal("actual client state does not match expected client state", actualClientState, expectedClientState)
 	}

--- a/internal/connection_repository/sql_connection_registrar_test.go
+++ b/internal/connection_repository/sql_connection_registrar_test.go
@@ -5,8 +5,10 @@ package connection_repository
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/RedHatInsights/cloud-connector/internal/config"
 	"github.com/RedHatInsights/cloud-connector/internal/domain"
@@ -89,7 +91,97 @@ func TestSqlConnectionRegistrar(t *testing.T) {
 }
 
 func TestSqlConnectionRegistrarUpdateTenantlessConnection(t *testing.T) {
-	t.Fatal("Implement this test!!", nil)
+	cfg := config.GetConfig()
+
+	database, err := db.InitializeDatabaseConnection(cfg)
+	if err != nil {
+		t.Fatal("Unable to connect to database: ", err)
+	}
+
+	orgID := domain.OrgID("")
+	account := domain.AccountID("")
+	clientID := domain.ClientID("update-tenantless-test-client-1")
+	dispatchersString := "{\"satellite\": {\"version\": \"0.2\"}}"
+
+	var dispatchers map[string]interface{}
+	err = json.Unmarshal([]byte(dispatchersString), &dispatchers)
+	if err != nil {
+		t.Fatal("unexpected error while creating dispatchers json doc", err)
+	}
+
+	var connectionRegistrar ConnectionRegistrar
+	connectionRegistrar, err = NewSqlConnectionRegistrar(cfg, database)
+	if err != nil {
+		t.Fatal("unexpected error while creating the SqlConnectionRegistrar", err)
+	}
+
+	verifyConnectionCountByClientID(t, database, clientID, 0)
+
+	connectorClientState := domain.ConnectorClientState{
+		OrgID:       orgID,
+		Account:     account,
+		ClientID:    clientID,
+		Dispatchers: dispatchers,
+	}
+
+	err = connectionRegistrar.Register(context.TODO(), connectorClientState)
+	if err != nil {
+		t.Fatal("unexpected error while registering a connection", err)
+	}
+
+	verifyConnectionCountByClientID(t, database, connectorClientState.ClientID, 1)
+
+	connectorClientState.OrgID = "1234"
+	connectorClientState.Account = "4321"
+
+	err = connectionRegistrar.Register(context.TODO(), connectorClientState)
+	if err != nil {
+		t.Fatal("unexpected error while registering a connection", err)
+	}
+
+	verifyConnectionCountByClientID(t, database, connectorClientState.ClientID, 1)
+
+	err = connectionRegistrar.Unregister(context.TODO(), connectorClientState.ClientID)
+	if err != nil {
+		t.Fatal("unexpected error while registering a connection", err)
+	}
+
+}
+
+func verifyConnectionCountByClientID(t *testing.T, database *sql.DB, clientID domain.ClientID, expectedConnectionCount int) {
+
+	connectionCount, err := getConnectionCountFromDatabase(database, clientID)
+	if err != nil {
+		t.Fatal("unexpected error while looking for connections by client-id", err)
+	}
+
+	if connectionCount != expectedConnectionCount {
+		t.Fatalf("expected connection count (%d) did not match connection count found in database (%d)", expectedConnectionCount, connectionCount)
+	}
+}
+
+func getConnectionCountFromDatabase(database *sql.DB, clientId domain.ClientID) (int, error) {
+
+	sqlQuery := "SELECT COUNT(*) FROM CONNECTIONS WHERE client_id = $1"
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+	defer cancel()
+
+	statement, err := database.Prepare(sqlQuery)
+	if err != nil {
+		return 0, err
+	}
+	defer statement.Close()
+
+	var count int
+
+	err = statement.QueryRowContext(ctx, clientId).Scan(&count)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
 }
 
 func verifyConnectorClientState(t *testing.T, expectedClientState, actualClientState domain.ConnectorClientState) {


### PR DESCRIPTION
[ ] Test this manually
- make sure a tenant-less connection can be updated on the next message received
- make sure tenant-less connections cannot be located by api 
- make sure tanant-less connections can be unregistered correctly
[ ] Modify "relaxed" connection locator to verify that the org_id is not empty (add a test here)
[ ] Add a test that verifies that a valid tenant can update a tenant-less connection
[ ] Add a test that verifies that a tenant-less connection can update a valid tenant connection

## What?
Explain what the change is linking any relevant JIRAs or Issues.

## Why?
Consider what business or engineering goal does this PR achieves.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
