### PR TITLE
[RHCLOUD-30651] Independently log cloud-connector dispatchers map

### DIFF
--- a/internal/cloud_connector/message_handlers.go
+++ b/internal/cloud_connector/message_handlers.go
@@ -218,6 +218,11 @@ func processDispatchers(logger *logrus.Entry, sourcesRecorder controller.Sources
 	if gotDispatchers == false {
 		logger.Debug("No dispatchers found")
 		return
+	} else {
+		dispatchersMessage, dispatchersMarshalled := json.Marshal(dispatchers)
+		if dispatchersMarshalled == nil {
+			logger.Debugf("Dispatchers found: %s", dispatchersMessage)
+		}
 	}
 
 	dispatchersMap := dispatchers.(map[string]interface{})


### PR DESCRIPTION
## What?
https://issues.redhat.com/browse/RHCLOUD-30651

## Why?
Dispatcher entries can be pulled directly from debug log messages for alternative parsing and application.

## How?
The dispatcher map is marshalled to JSON and printed.

## Testing
Tested with `TestProcessDispatchers()`. Example output:

```go
=== RUN   TestProcessDispatchers
time="2024-10-31T12:26:30-04:00" level=debug msg="Dispatchers found: {\"catalog\":{\"ApplicationType\":\"ima_app_type\",\"SourceRef\":\"ima_source_ref\",\"SrcName\":\"ima_source_name\",\"SrcType\":\"ima_source_type\"}}" func=github.com/RedHatInsights/cloud-connector/internal/cloud_connector.processDispatchers file="/home/jrodri/develop/cloud-connector/internal/cloud_connector/message_handlers.go:224" account=12345 client_id=98765 org_id=54321
--- PASS: TestProcessDispatchers (0.00s)
PASS
```

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
