### PR TITLE
[RHCLOUD-40005] bump Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM registry.access.redhat.com/ubi9/go-toolset as builder
 
 WORKDIR /go/src/app
 
+# The current ubi9 image does not include Go 1.24, so we specify it.
+# Adding "auto" will allow a newer version to be downloaded if specified in go.mod
+ARG GOTOOLCHAIN=go1.24.3+auto
+
 COPY go.mod go.sum ./
 
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/RedHatInsights/cloud-connector
 
-go 1.23.0
-
-toolchain go1.23.8
+go 1.24.3
 
 require (
 	github.com/RedHatInsights/tenant-utils v1.0.0


### PR DESCRIPTION
## What?
https://issues.redhat.com/browse/RHCLOUD-40005

## Why?
See linked Jira issue.

## How?
Bump Go version to 1.24.3, overriding version included in `ubi9/go-toolset`.

## Testing
- Built and ran test suite locally
- Built image locally

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Update the project to use Go 1.24.3 by adjusting module settings and Dockerfile toolchain argument.

Build:
- Bump Go version in go.mod to 1.24.3
- Add GOTOOLCHAIN ARG in Dockerfile to override UBI9 Go toolchain to 1.24.3+auto