### PR TITLE
[RHCLOUD-40555] Bump Go toolset version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ USER root
 
 RUN make build
 
-# Using ubi8-minimal due to its smaller footprint
+# Using ubi9-minimal due to its smaller footprint
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 RUN microdnf update -y


### PR DESCRIPTION
## What?

Rebuild image for playbook dispatcher.

## Why?

Pull updated Go toolset image (see [RHCLOUD-40555](https://issues.redhat.com/browse/RHCLOUD-40555))

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Build:
- Switch the Dockerfile base image from Red Hat UBI8 minimal to UBI9 minimal.