### PR TITLE
Add metric to track message processing latency

### DIFF
--- a/internal/mqtt/message_handlers.go
+++ b/internal/mqtt/message_handlers.go
@@ -58,7 +58,7 @@ func ControlMessageHandler(ctx context.Context, kafkaWriter *kafka.Writer, topic
 				Headers: []kafka.Header{
 					{TopicKafkaHeaderKey, []byte(message.Topic())},
 					{MessageIDKafkaHeaderKey, []byte(mqttMessageID)},
-					{DateReceivedHeaderKey, []byte(time.Now().UTC().String())},
+					{DateReceivedHeaderKey, []byte(time.Now().UTC().Format(time.RFC3339Nano))},
 				},
 				Key:   []byte(clientID),
 				Value: message.Payload(),


### PR DESCRIPTION
Add metric to track message processing latency

## Summary by Sourcery

Add a new histogram metric to track Kafka message processing latency by parsing the DateReceived header and recording the delay in Prometheus.

New Features:
- Introduce a Prometheus histogram metric cloud_connector_kafka_message_wait_time to measure how long messages wait in Kafka before processing
- Parse the DateReceived header timestamp and observe the wait duration in seconds for each message