### PR TITLE
RHINENG-19114; updating clowdapp file to specify UUID fields as TEXT for floorist compliance, updating HMS bucket secret

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -573,16 +573,16 @@ objects:
       - prefix: hms_analytics/cloud-connector/connections
         query: >-
           SELECT id,
-                  account,
-                  client_id,
+                  account::TEXT,
+                  client_id::TEXT,
                   dispatchers,
                   created_at,
                   updated_at,
                   stale_timestamp,
                   tags,
-                  message_id,
+                  message_id::TEXT,
                   message_sent,
-                  org_id,
+                  org_id::TEXT,
                   tenant_lookup_failure_count,
                   tenant_lookup_timestamp
           FROM connections;


### PR DESCRIPTION
## What?
Floorist seems to be complaining about UUID fields, so we're going to tell it to treat UUID's as text for metrics collection

## Why?
For metrics collection

## How?
Select statements for this service will select relevant fields as text

## Testing
n/a

## Anything Else?
n/a

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Update clowdapp deployment to cast UUID fields as TEXT for Floorist metrics compliance and refresh the HMS bucket secret

Enhancements:
- Cast account, client_id, message_id, and org_id fields as TEXT in clowdapp metrics query for Floorist compliance

Deployment:
- Update HMS bucket secret reference