### PR TITLE
Add auth type

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @loadtheaccumulator
+* @rexwhite

--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -154,6 +154,14 @@ func (ibccr *InventoryBasedConnectedClientRecorder) RecordConnectedClient(ctx co
 	var systemProfile = map[string]string{"rhc_client_id": string(rhcClient.ClientID)}
 	hostData["system_profile"] = systemProfile
 
+	// Extract and log the auth_type from the identity for debugging
+	authType, err := identity_utils.GetAuthType(identity)
+	if err != nil {
+		logger.WithFields(logrus.Fields{"error": err}).Warn("Unable to extract auth_type from identity in platform_metadata")
+	} else {
+		logger.WithFields(logrus.Fields{"auth_type": authType}).Info("Auth type from identity in platform_metadata")
+	}
+
 	certAuth, err := identity_utils.AuthenticatedWithCertificate(identity)
 	if err != nil {
 		logger.WithFields(logrus.Fields{"error": err}).Error("Unable to determine authentication type. Skipping inventory registration")

--- a/internal/platform/utils/identity_utils/identity.go
+++ b/internal/platform/utils/identity_utils/identity.go
@@ -21,6 +21,20 @@ func AuthenticatedWithCertificate(identity domain.Identity) (bool, error) {
 	return identityMap["auth_type"] == "cert-auth", nil
 }
 
+func GetAuthType(identity domain.Identity) (string, error) {
+
+	identityMap, err := convertIdentityToMap(identity)
+	if err != nil {
+		return "", err
+	}
+
+	if authType, ok := identityMap["auth_type"].(string); ok {
+		return authType, nil
+	}
+
+	return "", nil
+}
+
 func convertIdentityToMap(identity domain.Identity) (map[string]interface{}, error) {
 	idRaw, err := base64.StdEncoding.DecodeString(string(identity))
 	if err != nil {


### PR DESCRIPTION
## What?
Adding auth_type to message header in host_inventory Kafka message

## Why?
To test if it fixes a problem.

## Summary by Sourcery

Add authentication type information from the request identity into host inventory messages.

New Features:
- Include auth_type extracted from the request identity in host inventory Kafka message headers when available.

Enhancements:
- Introduce a reusable helper to retrieve auth_type from an identity payload for downstream use.