### PR TITLE
move auth_type logging to fix never reach issue

### DIFF
--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -135,6 +135,14 @@ func (ibccr *InventoryBasedConnectedClientRecorder) RecordConnectedClient(ctx co
 		"org_id":    rhcClient.OrgID,
 		"client_id": rhcClient.ClientID})
 
+	// Extract and log the auth_type from the identity for debugging
+	authType, err := identity_utils.GetAuthType(identity)
+	if err != nil {
+		logger.WithFields(logrus.Fields{"error": err}).Warn("Unable to extract auth_type from identity in platform_metadata")
+	} else {
+		logger.WithFields(logrus.Fields{"auth_type": authType}).Debug("Auth type from identity in platform_metadata")
+	}
+
 	if shouldHostBeRegisteredWithInventory(rhcClient, identity) == false {
 		logger.Debug("Skipping inventory registration")
 		return nil
@@ -153,14 +161,6 @@ func (ibccr *InventoryBasedConnectedClientRecorder) RecordConnectedClient(ctx co
 
 	var systemProfile = map[string]string{"rhc_client_id": string(rhcClient.ClientID)}
 	hostData["system_profile"] = systemProfile
-
-	// Extract and log the auth_type from the identity for debugging
-	authType, err := identity_utils.GetAuthType(identity)
-	if err != nil {
-		logger.WithFields(logrus.Fields{"error": err}).Warn("Unable to extract auth_type from identity in platform_metadata")
-	} else {
-		logger.WithFields(logrus.Fields{"auth_type": authType}).Info("Auth type from identity in platform_metadata")
-	}
 
 	certAuth, err := identity_utils.AuthenticatedWithCertificate(identity)
 	if err != nil {


### PR DESCRIPTION
## What?
refactor: log auth type before inventory registration decision

### OVERVIEW
* Moves the auth_type extraction and logging to occur before checking whether the host should be registered with inventory, ensuring this debug information is captured regardless of registration outcome.

RHINENG-25736

## Summary by Sourcery

Enhancements:
- Move auth_type extraction and logging to occur before the inventory registration decision in connected client recording.