### PR TITLE
RHINENG-25736: adding additional logging

### DIFF
--- a/internal/controller/account_resolver.go
+++ b/internal/controller/account_resolver.go
@@ -147,6 +147,14 @@ func (bar *BOPAccountIdResolver) MapClientIdToAccountId(ctx context.Context, cli
 
 	logger.WithFields(logrus.Fields{"account": jsonData.Identity.AccountNumber, "org_id": jsonData.Identity.Internal.OrgID}).Debug("Located account number and org ID for client")
 
+	// Log the full identity object for debugging
+	var fullIdentityMap map[string]interface{}
+	if err := json.Unmarshal(idRaw, &fullIdentityMap); err == nil {
+		if identityData, ok := fullIdentityMap["identity"].(map[string]interface{}); ok {
+			logger.WithFields(logrus.Fields{"identity_from_auth_gateway": identityData}).Debug("Full identity fields from Auth Gateway")
+		}
+	}
+
 	return domain.Identity(resp.Identity), domain.AccountID(jsonData.Identity.AccountNumber), domain.OrgID(jsonData.Identity.Internal.OrgID), nil
 }
 

--- a/internal/controller/connected_client_recorder.go
+++ b/internal/controller/connected_client_recorder.go
@@ -135,12 +135,12 @@ func (ibccr *InventoryBasedConnectedClientRecorder) RecordConnectedClient(ctx co
 		"org_id":    rhcClient.OrgID,
 		"client_id": rhcClient.ClientID})
 
-	// Extract and log the auth_type from the identity for debugging
-	authType, err := identity_utils.GetAuthType(identity)
+	// Extract and log all identity fields for debugging
+	identityMap, err := identity_utils.GetIdentityMap(identity)
 	if err != nil {
-		logger.WithFields(logrus.Fields{"error": err}).Warn("Unable to extract auth_type from identity in platform_metadata")
+		logger.WithFields(logrus.Fields{"error": err}).Warn("Unable to extract identity fields from identity in platform_metadata")
 	} else {
-		logger.WithFields(logrus.Fields{"auth_type": authType}).Debug("Auth type from identity in platform_metadata")
+		logger.WithFields(logrus.Fields{"identity_fields": identityMap}).Debug("Identity fields from platform_metadata")
 	}
 
 	if shouldHostBeRegisteredWithInventory(rhcClient, identity) == false {

--- a/internal/platform/utils/identity_utils/identity.go
+++ b/internal/platform/utils/identity_utils/identity.go
@@ -35,6 +35,10 @@ func GetAuthType(identity domain.Identity) (string, error) {
 	return "", nil
 }
 
+func GetIdentityMap(identity domain.Identity) (map[string]interface{}, error) {
+	return convertIdentityToMap(identity)
+}
+
 func convertIdentityToMap(identity domain.Identity) (map[string]interface{}, error) {
 	idRaw, err := base64.StdEncoding.DecodeString(string(identity))
 	if err != nil {


### PR DESCRIPTION
## What?
Adding additional logging

Fixes: RHINENG-25736

## Summary by Sourcery

Add richer identity logging for account resolution and connected client recording to aid debugging.

Enhancements:
- Log the full identity fields returned from the Auth Gateway when resolving account IDs.
- Log all identity fields from platform metadata in connected client recording instead of only the auth_type.
- Expose a utility to convert an identity into a map for reuse by logging and other callers.