### PR TITLE
RHINENG-25736: inject auth_type if missing

### DIFF
--- a/internal/controller/account_resolver.go
+++ b/internal/controller/account_resolver.go
@@ -155,6 +155,21 @@ func (bar *BOPAccountIdResolver) MapClientIdToAccountId(ctx context.Context, cli
 		}
 	}
 
+	// If auth_type is missing from the Auth Gateway response, set it to "cert-auth"
+	// since this endpoint is specifically for certificate authentication
+	if jsonData.Identity.AuthType == "" {
+		logger.Warn("Auth Gateway did not provide auth_type, setting to 'cert-auth' based on certauth endpoint")
+		jsonData.Identity.AuthType = "cert-auth"
+
+		// Re-encode the identity with auth_type added
+		updatedIdentity, err := json.Marshal(jsonData)
+		if err != nil {
+			logger.WithFields(logrus.Fields{"error": err}).Error("Unable to re-marshal identity after adding auth_type")
+			return "", "", "", err
+		}
+		resp.Identity = base64.StdEncoding.EncodeToString(updatedIdentity)
+	}
+
 	return domain.Identity(resp.Identity), domain.AccountID(jsonData.Identity.AccountNumber), domain.OrgID(jsonData.Identity.Internal.OrgID), nil
 }
 


### PR DESCRIPTION
## What?
fix: default missing auth_type to cert-auth in certificate auth resolver

### OVERVIEW
* Ensures certificate-auth-specific account resolution sets a default auth_type of "cert-auth" when absent in the Auth Gateway response, updating the encoded identity and adding appropriate logging and error handling.

FIXES: RHINENG-25736

## Summary by Sourcery

Default missing auth_type values to certificate authentication in the certificate-based account resolver and propagate the updated identity.

Bug Fixes:
- Ensure certificate-auth account resolution assigns a default auth_type of "cert-auth" when the Auth Gateway omits it, preventing downstream issues with missing auth_type.

Enhancements:
- Update the encoded identity payload and add logging when auth_type is inferred for certificate-auth requests.