### PR TITLE
RHINENG-23248: update golang to 1.25.9

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,10 +16,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.24
-      - uses: actions/checkout@v3
+          go-version: 1.25.9
+      - uses: actions/checkout@v5
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,13 +8,13 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.5]
+        go-version: [1.25.9]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
     - name: Run Tests

--- a/.github/workflows/sql-tests.yml
+++ b/.github/workflows/sql-tests.yml
@@ -24,10 +24,10 @@ jobs:
           - 5432:5432
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
-        go-version: 1.24.5
+        go-version: 1.25.9
     - name: Run Tests (including sql tests)
       run: make test test-sql

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 # Once built, copy to a smaller image and run from there
 FROM registry.access.redhat.com/ubi9/go-toolset as builder
 
+# Use Go 1.25.9 specifically
+ENV GOTOOLCHAIN=go1.25.9
+
 WORKDIR /go/src/app
 
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/cloud-connector
 
-go 1.24.5
+go 1.25.9
 
 require (
 	github.com/RedHatInsights/tenant-utils v1.0.0


### PR DESCRIPTION
## What?
feat: bump Go toolchain and workflows to 1.25.9

### OVERVIEW
* Update the project’s Go version in go.mod and all GitHub workflows to use Go 1.25 (1.25.9 in CI) instead of 1.24.x.
* Update GitHub Actions workflows to use newer versions of actions/setup-go and actions/checkout across linting, PR tests, and SQL tests.

FIXES: RHINENG-23248

## Summary by Sourcery

Bump the project Go toolchain to version 1.25.9 across source configuration and CI workflows.

Build:
- Update go.mod to require Go 1.25.9.
- Align GitHub Actions workflows (lint, PR tests, SQL tests) to run with Go 1.25.x/1.25.9.