### PR TITLE
update image repo location

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -708,7 +708,7 @@ parameters:
 - description: Image
   name: IMAGE
   required: true
-  value: quay.io/cloudservices/cloud-connector
+  value: quay.io/redhat-services-prod/insights-management-tenant/cloud-connector
 - description: Image tag
   name: IMAGE_TAG
   required: true


### PR DESCRIPTION
## What?
Update image location

Fixes: RHINENG-26290

## Summary by Sourcery

Build:
- Point the IMAGE parameter in clowdapp deployment config to the new quay.io/redhat-services-prod/insights-management-tenant/cloud-connector repository.