### PR TITLE
RHINENG-26514, add precommit hook for gitleaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## What?
RHINENG-26514, add precommit hook for gitleaks

## Why?
auth leak prevention

## How?
Adds a pre-commit file that checks for secrets that dont belong in the commit

## Testing
n/a

## Anything Else?
requires:
```
pip install pre-commit
pre-commit install
```

or

`dnf install pre-commit`

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add a pre-commit configuration to enforce basic formatting checks and prevent committing secrets using gitleaks

New Features:
- Add pre-commit hook configuration for gitleaks-based secret scanning

Build:
- Introduce pre-commit configuration with standard formatting and YAML integrity hooks