### PR TITLE
RHINENG-28438; Add RDS Volume usage to Grafana

### DIFF
--- a/dashboards/grafana-dashboard-insights-cloud-connector-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-cloud-connector-general.configmap.yaml
@@ -2379,6 +2379,104 @@ data:
           ],
           "title": "Go Routines",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${aws_resources_exporter}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 10,
+            "x": 0,
+            "y": 69
+          },
+          "id": 67,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${aws_resources_exporter}"
+              },
+              "editorMode": "code",
+              "expr": "rdsosmetrics_fileSys_usedPercent{mount_point=\"/rdsdbdata\", exported_instance=~\"cloud-connector-.*\"}",
+              "interval": "",
+              "legendFormat": "{{exported_instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "RDS storage usage",
+          "type": "timeseries"
         }
       ],
       "preload": false,


### PR DESCRIPTION
## What?
Adding an RDS Volume Usage widget to grafana

## Why?
A recent alert about storage usage revealed that we've no visual representation of usage, but Playbook Dispatcher does. This widget helps us understand our usage situation over time

## How?
Adds a json stanza specific to the widget, basically copied from playbook dispatcher

## Testing
n/a

## Anything Else?
although copied from playbook dispatcher, the widget had to be added/configured in the UI first but cannot be saved there. The json here was from the UI changes after configured to look at the CC data sources

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

New Features:
- Add a Grafana timeseries panel showing RDS storage usage for cloud-connector instances based on Prometheus metrics.