### PR TITLE
RHINENG-28748; Log resolved MQTT broker node hostname at connection time

### DIFF
--- a/internal/mqtt/broker_client.go
+++ b/internal/mqtt/broker_client.go
@@ -1,6 +1,10 @@
 package mqtt
 
 import (
+	"net"
+	"net/url"
+	"strings"
+
 	"github.com/RedHatInsights/cloud-connector/internal/platform/logger"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
@@ -11,6 +15,34 @@ type Subscriber struct {
 	Topic      string
 	EntryPoint MQTT.MessageHandler
 	Qos        byte
+}
+
+// logBrokerNode resolves the hostname in brokerUrl to an IP and reverse-DNS
+// hostname, then emits a structured log entry. This makes the actual physical
+// broker node visible in Kibana after each connect or reconnect, which is
+// otherwise obscured by the load-balanced VIP address.
+func logBrokerNode(brokerUrl string) {
+	fields := logrus.Fields{"broker_url": brokerUrl}
+
+	u, err := url.Parse(brokerUrl)
+	if err != nil {
+		logger.Log.WithFields(fields).Info("Connected to MQTT broker")
+		return
+	}
+
+	ips, err := net.LookupHost(u.Hostname())
+	if err != nil || len(ips) == 0 {
+		logger.Log.WithFields(fields).Info("Connected to MQTT broker")
+		return
+	}
+
+	fields["broker_resolved_ip"] = ips[0]
+
+	if hostnames, err := net.LookupAddr(ips[0]); err == nil && len(hostnames) > 0 {
+		fields["broker_node"] = strings.TrimSuffix(hostnames[0], ".")
+	}
+
+	logger.Log.WithFields(fields).Info("Connected to MQTT broker")
 }
 
 func CreateBrokerConnection(brokerUrl string, brokerConfigFuncs ...MqttClientOptionsFunc) (MQTT.Client, error) {
@@ -27,7 +59,7 @@ func CreateBrokerConnection(brokerUrl string, brokerConfigFuncs ...MqttClientOpt
 		return nil, token.Error()
 	}
 
-	logger.Log.Info("Connected to MQTT broker: ", brokerUrl)
+	logBrokerNode(brokerUrl)
 
 	return mqttClient, nil
 }

--- a/internal/mqtt/broker_client.go
+++ b/internal/mqtt/broker_client.go
@@ -59,7 +59,5 @@ func CreateBrokerConnection(brokerUrl string, brokerConfigFuncs ...MqttClientOpt
 		return nil, token.Error()
 	}
 
-	logBrokerNode(brokerUrl)
-
 	return mqttClient, nil
 }

--- a/internal/mqtt/client_options.go
+++ b/internal/mqtt/client_options.go
@@ -132,7 +132,9 @@ func WithOnConnectHandler(handler func(MQTT.Client)) MqttClientOptionsFunc {
 			if len(servers) > 0 {
 				logBrokerNode(servers[0].String())
 			}
-			handler(c)
+			if handler != nil {
+				handler(c)
+			}
 		})
 		return nil
 	}

--- a/internal/mqtt/client_options.go
+++ b/internal/mqtt/client_options.go
@@ -126,7 +126,14 @@ func WithAutoReconnect(autoReconnect bool) MqttClientOptionsFunc {
 func WithOnConnectHandler(handler func(MQTT.Client)) MqttClientOptionsFunc {
 	return func(opts *MQTT.ClientOptions) error {
 		logger.Log.Tracef("Setting the on-connect handler")
-		opts.SetOnConnectHandler(handler)
+		opts.SetOnConnectHandler(func(c MQTT.Client) {
+			reader := c.OptionsReader()
+			servers := (&reader).Servers()
+			if len(servers) > 0 {
+				logBrokerNode(servers[0].String())
+			}
+			handler(c)
+		})
 		return nil
 	}
 }


### PR DESCRIPTION
## Why

The `cloud-connector-mqtt-message-consumer` pod connects to the MQTT broker
via a load-balanced DNS address (e.g. `ssl://connect.cloud.redhat.com:8883`).
When the pod starts or restarts, it lands on whichever physical broker node the
load balancer assigns — but the existing log entry only records the VIP address,
not the underlying node.

During a production incident involving broken inter-node message routing in the
HarperDB MQTT cluster, determining which broker node the pod was connected to
required manually downloading `oc logs`, grepping for a startup line, and
cross-referencing with `ss`/`getent hosts` output from test VMs. This had to be
repeated every time the pod restarted (which happens automatically via
`Shutdown_On_MQTT_Connection_Lost: true` whenever the broker drops the
connection).

## What

Adds a `logBrokerNode` helper that, after a successful MQTT connection:

1. Parses the hostname from the broker URL
2. Resolves it to an IP via `net.LookupHost`
3. Reverse-DNS looks up the IP via `net.LookupAddr`
4. Emits a structured log entry with `broker_url`, `broker_resolved_ip`, and
   `broker_node` as separate fields

**Example Kibana log entry:**
```json
{
  "message": "Connected to MQTT broker",
  "broker_url": "ssl://connect.cloud.redhat.com:8883",
  "broker_resolved_ip": "172.233.212.202",
  "broker_node": "rh-broker-prod-us-ord02.harperdbcloud.com"
}
```
This is called in two places:

CreateBrokerConnection:  fires on initial pod startup
WithOnConnectHandler: wraps the caller's handler to also fire on any subsequent reconnect event, covering the AutoReconnect: true path
Both paths degrade gracefully: if DNS resolution fails for any reason, the log entry is still emitted with just broker_url and no error is returned.

## How?
internal/mqtt/broker_client.go 
- adds logBrokerNode, replaces the unstructured Info("Connected to MQTT broker: ", brokerUrl) call
internal/mqtt/client_options.go  
- decorates WithOnConnectHandler to wrap the supplied handler with a logBrokerNode call, following the same pattern already used in WithConnectionLostHandler for metrics

## Testing
No additional tests as this is a log-only function, nothing structural.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Log the resolved MQTT broker node details when a client connects or reconnects to aid production diagnostics.

Enhancements:
- Add a helper to resolve the MQTT broker URL to IP and reverse-DNS hostname and emit them as structured log fields on successful connection.
- Wrap the MQTT on-connect handler to log broker node details on every reconnect in addition to initial connection.